### PR TITLE
Add improvement in redirecting to error page scenario

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -243,8 +243,11 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         if (isWebAuthnEnabled()) {
             String data = initiateFido2AuthenticationRequest(user, appID);
             boolean isDataNull = StringUtils.isBlank(data);
-            redirectUrl = getRedirectUrl(isDataNull, loginPage, URLEncoder.encode(data, IdentityCoreConstants.UTF_8),
-                    response, user, context);
+            String urlEncodedData = null;
+            if (!isDataNull) {
+                urlEncodedData = URLEncoder.encode(data, IdentityCoreConstants.UTF_8);
+            }
+            redirectUrl = getRedirectUrl(isDataNull, loginPage, urlEncodedData, response, user, context);
         } else {
             AuthenticateRequestData data = initiateFidoAuthenticationRequest(user, appID);
             boolean isDataNull = (data == null);

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -338,7 +338,10 @@ public class WebAuthnService {
             user.setTenantDomain(tenantDomain);
             user.setUserStoreDomain(storeDomain);
             if (userStorage.getFIDO2RegistrationsByUsername(user.toString()).isEmpty()) {
-                throw new AuthenticationFailedException("The username \"" + user.toString() + "\" is not registered.");
+                if (log.isDebugEnabled()) {
+                    log.debug("No registered device found for user :" + user.toString());
+                }
+                return null;
             } else {
                 RelyingParty relyingParty = buildRelyingParty(originUrl);
                 AssertionRequestWrapper request = new AssertionRequestWrapper(


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/7166

### Problem
Previously, if a device is not registered for a specific user, and the user tries to authenticate to a service provider by setting fido as the second step, it will throw the following AuthenticationFailedException. In the client-side, it will try to redirect to the callBackURL of the service provider. 

```
[2019-12-20 14:43:16,880] [55ba95fd-cd89-443b-b9f6-e8113bff37fa] ERROR {org.wso2.carbon.identity.application.authentication.framework.handler.step.impl.DefaultStepHandler} - Authentication failed exception! org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException: The username "sam@carbon.super" is not registered.
	at org.wso2.carbon.identity.application.authenticator.fido2.core.WebAuthnService.startAuthentication(WebAuthnService.java:341)
	at org.wso2.carbon.identity.application.authenticator.fido.FIDOAuthenticator.initiateFido2AuthenticationRequest(FIDOAuthenticator.java:202)
	at org.wso2.carbon.identity.application.authenticator.fido.FIDOAuthenticator.getRedirectUrl(FIDOAuthenticator.java:244)
	at org.wso2.carbon.identity.application.authenticator.fido.FIDOAuthenticator.initiateAuthenticationRequest(FIDOAuthenticator.java:136)
	at org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator.process(AbstractApplicationAuthenticator.java:71)
	at org.wso2.carbon.identity.application.authenticator.fido.FIDOAuthenticator.process(FIDOAuthenticator.java:65)
	at org.wso2.carbon.identity.application.authentication.framework.handler.step.impl.DefaultStepHandler.doAuthentication(DefaultStepHandler.java:506)
	at org.wso2.carbon.identity.application.authentication.framework.handler.step.impl.DefaultStepHandler.handle(DefaultStepHandler.java:271)
	at org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.DefaultStepBasedSequenceHandler.handle(DefaultStepBasedSequenceHandler.java:185)
	at org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.GraphBasedSequenceHandler.handle(GraphBasedSequenceHandler.java:111)
	at org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultAuthenticationRequestHandler.handle(DefaultAuthenticationRequestHandler.java:158)
	at org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultRequestCoordinator.handle(DefaultRequestCoordinator.java:240)
	at org.wso2.carbon.identity.application.authentication.framework.servlet.CommonAuthenticationServlet.doPost(CommonAuthenticationServlet.java:53)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:660)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:741)
	at org.eclipse.equinox.http.helper.ContextPathServletAdaptor.service(ContextPathServletAdaptor.java:37)
	at org.eclipse.equinox.http.servlet.internal.ServletRegistration.service(ServletRegistration.java:61)
	at org.eclipse.equinox.http.servlet.internal.ProxyServlet.processAlias(ProxyServlet.java:128)
	at org.eclipse.equinox.http.servlet.internal.ProxyServlet.service(ProxyServlet.java:60)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:741)
	at org.wso2.carbon.tomcat.ext.servlet.DelegationServlet.service(DelegationServlet.java:68)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.wso2.carbon.identity.captcha.filter.CaptchaFilter.doFilter(CaptchaFilter.java:66)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.owasp.csrfguard.CsrfGuardFilter.doFilter(CsrfGuardFilter.java:72)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.wso2.carbon.tomcat.ext.filter.CharacterSetFilter.doFilter(CharacterSetFilter.java:65)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.filters.HttpHeaderSecurityFilter.doFilter(HttpHeaderSecurityFilter.java:126)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:490)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
	at org.wso2.carbon.identity.context.rewrite.valve.TenantContextRewriteValve.invoke(TenantContextRewriteValve.java:80)
	at org.wso2.carbon.identity.authz.valve.AuthorizationValve.invoke(AuthorizationValve.java:110)
	at org.wso2.carbon.identity.auth.valve.AuthenticationValve.invoke(AuthenticationValve.java:74)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.continueInvocation(CompositeValve.java:99)
	at org.wso2.carbon.tomcat.ext.valves.TomcatValveContainer.invokeValves(TomcatValveContainer.java:49)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.invoke(CompositeValve.java:62)
	at org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve.invoke(CarbonStuckThreadDetectionValve.java:145)
	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:678)
	at org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve.invoke(CarbonContextCreatorValve.java:57)
	at org.wso2.carbon.tomcat.ext.valves.RequestEncodingValve.invoke(RequestEncodingValve.java:49)
	at org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve.invoke(RequestCorrelationIdValve.java:116)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:408)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:853)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1587)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:748)
```

### Proposed changes in this pull request
With this PR, this behaviour is changed such that the user will be redirected to an error page stating that a device is not registered for the user.
