### PR TITLE
Support for updating display name of a registered FIDO2 device

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/CredentialIdApi.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/CredentialIdApi.java
@@ -7,6 +7,8 @@ import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.factori
 import io.swagger.annotations.ApiParam;
 
 import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.ErrorDTO;
+import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.PatchRequestDTO;
+import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.RegistrationObjectDTO;
 
 import java.util.List;
 
@@ -46,6 +48,29 @@ public class CredentialIdApi  {
     public Response credentialIdDelete(@ApiParam(value = "credentialId",required=true ) @PathParam("credentialId")  String credentialId)
     {
     return delegate.credentialIdDelete(credentialId);
+    }
+    @PATCH
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Update display name of device by username and credentialId.\n", notes = "This API is used to update display name of a device by username and credentialId.\n\n<b>Permission required:</b>\n * /permission/admin/login\n", response = RegistrationObjectDTO.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Successful response"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Bad Request"),
+        
+        @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized"),
+        
+        @io.swagger.annotations.ApiResponse(code = 403, message = "Resource Forbidden"),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Not Found"),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
+
+    public Response credentialIdPatch(@ApiParam(value = "credentialId",required=true ) @PathParam("credentialId")  String credentialId,
+    @ApiParam(value = "" ,required=true ) PatchRequestDTO body)
+    {
+    return delegate.credentialIdPatch(credentialId,body);
     }
 }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/CredentialIdApiService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/CredentialIdApiService.java
@@ -4,6 +4,8 @@ import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.*;
 import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.*;
 
 import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.ErrorDTO;
+import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.PatchRequestDTO;
+import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.RegistrationObjectDTO;
 
 import java.util.List;
 
@@ -14,5 +16,6 @@ import javax.ws.rs.core.Response;
 
 public abstract class CredentialIdApiService {
     public abstract Response credentialIdDelete(String credentialId);
+    public abstract Response credentialIdPatch(String credentialId,PatchRequestDTO body);
 }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/DefaultApi.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/DefaultApi.java
@@ -7,6 +7,7 @@ import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.factori
 import io.swagger.annotations.ApiParam;
 
 import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.ErrorDTO;
+import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.RegistrationObjectDTO;
 
 import java.util.List;
 
@@ -29,7 +30,7 @@ public class DefaultApi  {
     
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Device Metadata\n", notes = "This API is used to get fido metadata by username.\n\n<b>Permission required:</b>\n * /permission/admin/login\n", response = Object.class, responseContainer = "List")
+    @io.swagger.annotations.ApiOperation(value = "Device Metadata\n", notes = "This API is used to get fido metadata by username.\n\n<b>Permission required:</b>\n * /permission/admin/login\n", response = RegistrationObjectDTO.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "All available fido metadata for a user."),
         

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/DefaultApiService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/DefaultApiService.java
@@ -4,6 +4,7 @@ import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.*;
 import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.*;
 
 import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.ErrorDTO;
+import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.RegistrationObjectDTO;
 
 import java.util.List;
 

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/dto/PatchDTO.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/dto/PatchDTO.java
@@ -1,0 +1,85 @@
+package org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto;
+
+import io.swagger.annotations.ApiModel;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+/**
+ * A JSONPatch as defined by RFC 6902. Patch operation is supported only for root level attributes of an Identity Provider.
+ **/
+
+
+@ApiModel(description = "A JSONPatch as defined by RFC 6902. Patch operation is supported only for root level attributes of an Identity Provider.")
+public class PatchDTO  {
+  
+  
+  public enum OperationEnum {
+     ADD,  REMOVE,  REPLACE, 
+  };
+  @NotNull
+  private OperationEnum operation = null;
+  
+  @NotNull
+  private String path = null;
+  
+  
+  private String value = null;
+
+  
+  /**
+   * The operation to be performed
+   **/
+  @ApiModelProperty(required = true, value = "The operation to be performed")
+  @JsonProperty("operation")
+  public OperationEnum getOperation() {
+    return operation;
+  }
+  public void setOperation(OperationEnum operation) {
+    this.operation = operation;
+  }
+
+  
+  /**
+   * A JSON-Pointer
+   **/
+  @ApiModelProperty(required = true, value = "A JSON-Pointer")
+  @JsonProperty("path")
+  public String getPath() {
+    return path;
+  }
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  
+  /**
+   * The value to be used within the operations
+   **/
+  @ApiModelProperty(value = "The value to be used within the operations")
+  @JsonProperty("value")
+  public String getValue() {
+    return value;
+  }
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class PatchDTO {\n");
+    
+    sb.append("  operation: ").append(operation).append("\n");
+    sb.append("  path: ").append(path).append("\n");
+    sb.append("  value: ").append(value).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/dto/PatchRequestDTO.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/dto/PatchRequestDTO.java
@@ -1,0 +1,30 @@
+package org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.PatchDTO;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class PatchRequestDTO extends ArrayList<PatchDTO> {
+  
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class PatchRequestDTO {\n");
+    sb.append("  " + super.toString()).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/dto/RegistrationObjectDTO.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/gen/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/dto/RegistrationObjectDTO.java
@@ -1,0 +1,29 @@
+package org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class RegistrationObjectDTO extends ArrayList<Object> {
+  
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class RegistrationObjectDTO {\n");
+    sb.append("  " + super.toString()).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/common/FIDO2Constants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/common/FIDO2Constants.java
@@ -24,6 +24,7 @@ public class FIDO2Constants {
     public static final String EQUAL_OPERATOR = "=";
     private static final String FIDO2_ERROR_CODE_PREFIX = "FID-";
     public static final String APP_ID = "appId";
+    public static final String DISPLAY_NAME_PATH = "/displayName";
 
     /**
      * Enum for error messages.
@@ -51,7 +52,14 @@ public class FIDO2Constants {
         ERROR_CODE_DELETE_REGISTRATION_INVALID_CREDENTIAL("50009", "Error while deleting user " +
                 "credentials.", "Invalid credentialId : %s "),
         ERROR_CODE_DELETE_REGISTRATION_CREDENTIAL_UNAVAILABLE("50010", "Error while deleting user " +
-                "credentials.", "FIDO2 device registration is not available with credentialId : %s ");
+                "credentials.", "FIDO2 device registration is not available with credentialId : %s "),
+        ERROR_CODE_UPDATE_REGISTRATION_INVALID_CREDENTIAL("50011", "Error while updating display name" +
+                " of device.", "Invalid credentialId : %s "),
+        ERROR_CODE_UPDATE_REGISTRATION_CREDENTIAL_UNAVAILABLE("50012", "Error while updating display " +
+                "name of device.", "FIDO2 device registration is not available with credentialId : %s "),
+        ERROR_CODE_UPDATE_DISPLAY_NAME("50013", "Error while updating display name of device.",
+                "A system error occurred while updating display name of device with credentialId : %s "),
+        ERROR_CODE_INVALID_INPUT("50014", "Invalid input.", "One of the given inputs is invalid.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/CredentialIdApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/CredentialIdApiServiceImpl.java
@@ -16,12 +16,16 @@
 
 package org.wso2.carbon.identity.application.authenticator.fido2.endpoint.impl;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authenticator.fido2.core.WebAuthnService;
 import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.CredentialIdApiService;
 import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.common.FIDO2Constants;
 import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.common.Util;
+import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.PatchDTO;
+import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.dto.PatchRequestDTO;
 import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorClientException;
 import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorServerException;
 
@@ -58,4 +62,57 @@ public class CredentialIdApiServiceImpl extends CredentialIdApiService {
                     (FIDO2Constants.ErrorMessages.ERROR_CODE_DELETE_CREDENTIALS, credentialId)).build();
         }
     }
+
+    @Override
+    public Response credentialIdPatch(String credentialId, PatchRequestDTO body) {
+
+        WebAuthnService webAuthnService = new WebAuthnService();
+        try {
+            String newDisplayName = processAndFetchNewDisplayName(body);
+            if (StringUtils.isNotBlank(newDisplayName)) {
+                webAuthnService.updateFIDO2DeviceDisplayName(credentialId, newDisplayName);
+                return Response.ok().build();
+            }
+            return Response.status(Response.Status.BAD_REQUEST).entity(Util.getErrorDTO(FIDO2Constants.ErrorMessages
+                    .ERROR_CODE_INVALID_INPUT, null)).build();
+        } catch (FIDO2AuthenticatorClientException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Client error while updating the display name of FIDO device with credentialId: " +
+                        credentialId, e);
+            }
+            if (FIDO2Constants.ErrorMessages.ERROR_CODE_UPDATE_REGISTRATION_CREDENTIAL_UNAVAILABLE.getCode()
+                    .equals(e.getErrorCode())) {
+                return Response.status(Response.Status.NOT_FOUND).entity(Util.getErrorDTO(FIDO2Constants.ErrorMessages
+                        .ERROR_CODE_UPDATE_REGISTRATION_CREDENTIAL_UNAVAILABLE, credentialId)).build();
+            }
+            return Response.status(Response.Status.BAD_REQUEST).entity(Util.getErrorDTO(FIDO2Constants.ErrorMessages
+                    .ERROR_CODE_UPDATE_REGISTRATION_INVALID_CREDENTIAL, credentialId)).build();
+        } catch (FIDO2AuthenticatorServerException e) {
+            LOG.error("Unexpected server exception while updating the display name of device with credentialId: " +
+                    credentialId, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(Util.getErrorDTO
+                    (FIDO2Constants.ErrorMessages.ERROR_CODE_UPDATE_DISPLAY_NAME, credentialId)).build();
+        }
+    }
+
+    private String processAndFetchNewDisplayName(PatchRequestDTO body) {
+
+        if (CollectionUtils.isEmpty(body)) {
+            return null;
+        }
+
+        String newDisplayName = null;
+        for (PatchDTO patch : body) {
+            String path = patch.getPath();
+            PatchDTO.OperationEnum operation = patch.getOperation();
+
+            // We support only 'REPLACE' patch operation for /displayName path.
+            if (operation == PatchDTO.OperationEnum.REPLACE && FIDO2Constants.DISPLAY_NAME_PATH.equals(path)) {
+                newDisplayName = patch.getValue();
+            }
+        }
+
+        return newDisplayName;
+    }
+
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/main/resources/fido.yaml
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2.endpoint/src/main/resources/fido.yaml
@@ -278,6 +278,48 @@ paths:
             $ref: '#/definitions/Error'
       tags:
         - me
+    patch:
+      description: |
+        This API is used to update display name of a device by username and credentialId.
+
+        <b>Permission required:</b>
+         * /permission/admin/login
+      summary: |
+        Update display name of device by username and credentialId.
+      parameters:
+        - name: credentialId
+          in: path
+          description:  credentialId
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/PatchRequest'
+      responses:
+        200:
+          description: Successful response
+          schema:
+            $ref: '#/definitions/RegistrationObject'
+        400:
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Unauthorized
+        403:
+          description: Resource Forbidden
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Server Error
+          schema:
+            $ref: '#/definitions/Error'
+      tags:
+        - me
 
   # Endpoint used to get device metadata by username
   /:
@@ -293,21 +335,7 @@ paths:
         200:
           description: All available fido metadata for a user.
           schema:
-            type: array
-            items:
-              type: object
-              example:
-                signatureCount: 0
-                userIdentity:
-                  name: admin@carbon.super
-                  displayName: admin
-                  id: uq99g9NLogr-k3OC6i1UDhmfeiZeKbygGPBcKoq96UI
-                credential:
-                  credentialId: S2_HP9mz3wt0_XFrF4QEqcCOn-mblJ2e6YBX79MqU3cwEH-7UXd0oxn0-QKpB4HsRpe3jerAyT233hKdq3vfrQ
-                  userHandle: uq99g9NLogr-k3OC6i1UDhmfeiZeKbygGPBcKoq96UI
-                  publicKeyCose: pSJYIDbPBKVOQWaZAraIPfggBxVHVGuYPROvWR5WigNbh5iiAyYBAiFYIIbF8aqhhWrQYbQnQJY7WrjiQD84qvQulLfGjbUgk1yAIAE
-                  signatureCount: 0
-                registrationTime: "2019-11-26T05:16:19.932Z"
+            $ref: '#/definitions/RegistrationObject'
         400:
           description: Bad Request
           schema:
@@ -340,6 +368,62 @@ definitions:
         type: string
         example: "Some Error Description"
 
+  #-----------------------------------------------------
+  # Patch Request object
+  #-----------------------------------------------------
+  PatchRequest:
+    type: array
+    items:
+      $ref: '#/definitions/Patch'
+
+  #-----------------------------------------------------
+  # JSONPatch
+  #-----------------------------------------------------
+  Patch:
+    description: A JSONPatch as defined by RFC 6902. Patch operation is supported only for root level attributes of
+      an Identity Provider.
+    required:
+      - operation
+      - path
+    properties:
+      operation:
+        type: string
+        description: The operation to be performed
+        enum:
+          - ADD
+          - REMOVE
+          - REPLACE
+        example: REPLACE
+      path:
+        type: string
+        description: A JSON-Pointer
+        example: '/displayName'
+      value:
+        type: string
+        description: The value to be used within the operations
+        example: 'Device01'
+
+  #-----------------------------------------------------
+  # The Registration Object
+  #-----------------------------------------------------
+  RegistrationObject:
+    type: array
+    items:
+      type: object
+      example:
+        signatureCount: 0
+        userIdentity:
+          name: admin@carbon.super
+          displayName: admin
+          id: uq99g9NLogr-k3OC6i1UDhmfeiZeKbygGPBcKoq96UI
+        credential:
+          credentialId: S2_HP9mz3wt0_XFrF4QEqcCOn-mblJ2e6YBX79MqU3cwEH-7UXd0oxn0-QKpB4HsRpe3jerAyT233hKdq3vfrQ
+          userHandle: uq99g9NLogr-k3OC6i1UDhmfeiZeKbygGPBcKoq96UI
+          publicKeyCose: pSJYIDbPBKVOQWaZAraIPfggBxVHVGuYPROvWR5WigNbh5iiAyYBAiFYIIbF8aqhhWrQYbQnQJY7WrjiQD84qvQulLfGjbUgk1yAIAE
+          signatureCount: 0
+        registrationTime: "2019-11-26T05:16:19.932Z"
+        isUsernamelessSupported : false
+        displayName : "My Device"
 #-----------------------------------------------------
 securityDefinitions:
   BasicAuth:

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -564,6 +564,45 @@ public class WebAuthnService {
         }
     }
 
+    /**
+     * Update the display name of a registered device.
+     *
+     * @param credentialId   Credential ID.
+     * @param newDisplayName New display name to be updated.
+     * @throws FIDO2AuthenticatorClientException
+     * @throws FIDO2AuthenticatorServerException
+     */
+    public void updateFIDO2DeviceDisplayName(String credentialId, String newDisplayName)
+            throws FIDO2AuthenticatorClientException, FIDO2AuthenticatorServerException {
+
+        if (StringUtils.isBlank(credentialId)) {
+            throw new FIDO2AuthenticatorClientException("Credential ID must not be empty.",
+                    FIDO2AuthenticatorConstants.ClientExceptionErrorCodes
+                            .ERROR_CODE_UPDATE_REGISTRATION_INVALID_CREDENTIAL.getErrorCode());
+        }
+
+        final ByteArray identifier;
+        try {
+            identifier = ByteArray.fromBase64Url(credentialId);
+        } catch (Base64UrlException e) {
+            throw new FIDO2AuthenticatorClientException("The Credential ID: " + credentialId + " is not a valid " +
+                    "Base64Url data.", FIDO2AuthenticatorConstants.ClientExceptionErrorCodes
+                    .ERROR_CODE_UPDATE_REGISTRATION_INVALID_CREDENTIAL.getErrorCode(), e);
+        }
+
+        User user = User.getUserFromUserName(CarbonContext.getThreadLocalCarbonContext().getUsername());
+        user.setTenantDomain(CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        Optional<FIDO2CredentialRegistration> credentialRegistration =
+                userStorage.getFIDO2RegistrationByUsernameAndCredentialId(user.toString(), identifier);
+
+        if (!credentialRegistration.isPresent()) {
+            throw new FIDO2AuthenticatorClientException("Credential ID not registered: " + credentialId,
+                    FIDO2AuthenticatorConstants.ClientExceptionErrorCodes
+                            .ERROR_CODE_UPDATE_REGISTRATION_CREDENTIAL_UNAVAILABLE.getErrorCode());
+        }
+        userStorage.updateFIDO2DeviceDisplayName(user, credentialRegistration.get(), newDisplayName);
+    }
+
     private RelyingParty buildRelyingParty(URL originUrl) {
 
         readTrustedOrigins();
@@ -620,6 +659,12 @@ public class WebAuthnService {
                         .getSignatureCounter())
                 .build();
 
+        boolean requireResidentKey = false;
+        if (publicKeyCredentialCreationOptions.getAuthenticatorSelection().isPresent()) {
+            requireResidentKey =
+                    publicKeyCredentialCreationOptions.getAuthenticatorSelection().get().isRequireResidentKey();
+        }
+
         FIDO2CredentialRegistration reg = FIDO2CredentialRegistration.builder()
                 .userIdentity(userIdentity)
                 .registrationTime(clock.instant())
@@ -627,6 +672,8 @@ public class WebAuthnService {
                 .signatureCount(response.getCredential().getResponse().getParsedAuthenticatorData()
                         .getSignatureCounter())
                 .attestationMetadata(registration.getAttestationMetadata())
+                .displayName(null)
+                .isUsernamelessSupported(requireResidentKey)
                 .build();
         userStorage.addFIDO2RegistrationByUsername(userIdentity.getName(), reg);
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/dto/FIDO2CredentialRegistration.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/dto/FIDO2CredentialRegistration.java
@@ -49,9 +49,21 @@ public class FIDO2CredentialRegistration {
 
     private Optional<Attestation> attestationMetadata;
 
+    private String displayName;
+    private boolean isUsernamelessSupported;
+
     @JsonProperty("registrationTime")
     public String getRegistrationTimestamp() {
         return registrationTime.toString();
     }
 
+    public String getDisplayName() {
+
+        return displayName;
+    }
+
+    public boolean getIsUsernamelessSupported() {
+
+        return isUsernamelessSupported;
+    }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2AuthenticatorConstants.java
@@ -36,7 +36,10 @@ public class FIDO2AuthenticatorConstants {
 
     public static final String TIME_REGISTERED = "TIME_REGISTERED";
     public static final String USER_IDENTITY = "USER_IDENTITY";
+    public static final String DISPLAY_NAME = "DISPLAY_NAME";
+    public static final String IS_USERNAMELESS_SUPPORTED = "IS_USERNAMELESS_SUPPORTED";
     public static final String TRUSTED_ORIGINS = "FIDO.FIDO2TrustedOrigins.Origin";
+    public static final String USERNAMELESS_SUPPORTED = "1";
 
     public static final String APPLICATION_NAME = "WSO2 Identity Server";
     public static final String FIDO2_DEVICE_STORE = "FIDO2_DEVICE_STORE";
@@ -75,7 +78,15 @@ public class FIDO2AuthenticatorConstants {
                 "(TENANT_ID, DOMAIN_NAME, USER_NAME, TIME_REGISTERED, USER_HANDLE, CREDENTIAL_ID, PUBLIC_KEY_COSE, " +
                 "SIGNATURE_COUNT, USER_IDENTITY ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
+        public static final String ADD_FIDO2_DEVICE_REGISTRATION_QUERY = "INSERT INTO FIDO2_DEVICE_STORE " +
+                "(TENANT_ID, DOMAIN_NAME, USER_NAME, TIME_REGISTERED, USER_HANDLE, CREDENTIAL_ID, PUBLIC_KEY_COSE, " +
+                "SIGNATURE_COUNT, USER_IDENTITY, DISPLAY_NAME, IS_USERNAMELESS_SUPPORTED) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
         public static final String DELETE_DEVICE_REGISTRATION_BY_USERNAME_AND_ID = "DELETE FROM FIDO2_DEVICE_STORE " +
+                "WHERE TENANT_ID = ? AND DOMAIN_NAME = ? AND USER_NAME = ? AND CREDENTIAL_ID = ?";
+
+        public static final String UPDATE_DEVICE_DISPLAY_NAME = "UPDATE FIDO2_DEVICE_STORE SET DISPLAY_NAME = ? " +
                 "WHERE TENANT_ID = ? AND DOMAIN_NAME = ? AND USER_NAME = ? AND CREDENTIAL_ID = ?";
 
         public static final String UPDATE_DOMAIN_QUERY = "UPDATE FIDO2_DEVICE_STORE SET DOMAIN_NAME = ? " +
@@ -95,7 +106,9 @@ public class FIDO2AuthenticatorConstants {
         ERROR_CODE_FINISH_REGISTRATION_INVALID_REQUEST("50006"),
         ERROR_CODE_FINISH_REGISTRATION_USERNAME_AND_CREDENTIAL_ID_EXISTS("50007"),
         ERROR_CODE_DELETE_REGISTRATION_INVALID_CREDENTIAL("50009"),
-        ERROR_CODE_DELETE_REGISTRATION_CREDENTIAL_UNAVAILABLE("50010");
+        ERROR_CODE_DELETE_REGISTRATION_CREDENTIAL_UNAVAILABLE("50010"),
+        ERROR_CODE_UPDATE_REGISTRATION_INVALID_CREDENTIAL("50011"),
+        ERROR_CODE_UPDATE_REGISTRATION_CREDENTIAL_UNAVAILABLE("50012");
 
         private String errorCode;
 


### PR DESCRIPTION
Resolves: 
- https://github.com/wso2/product-is/issues/6970
- https://github.com/wso2/product-is/issues/7151

### Proposed changes in this pull request
- With this PR the metadata of a FIDO2 device is improved to support a display name and whether the device is supporting usernameless authentication or not. Following is a sample response from the metadata endpoint.
```
{
      "isUsernamelessSupported" : true,
      "registrationTime" : "2020-01-08T06:27:34.119Z",
      "signatureCount" : 0,
      "displayName" : "MacOS",
      "credential" : {
         "publicKeyCose" : "pSJYIGQ21TS0V03Anczfz-BC1oFrzcF301yq2GaSA0vNqGdIAyYBAiFYILOpQGcP_Gnjl6Ok3h-4JVQF6tIKN79dPg0ytv1jTrWbIAE",
         "credentialId" : "Adn63caA5UxpAAgbKPvmKec14qBHXlJW2O6XngDILP1uh27KK7RCJg7VkJGE3pNdAsP-3ID6jDn1Qk34Qi9yCHiiRlejBV1gWmn17RrpFqp7KM-cBdE",
         "userHandle" : "q1DcsnV_4d2bk1UeMOUiMJIUOB3SQIr81mIZZ7Z4LMs",
         "signatureCount" : 1578464194
      },
      "userIdentity" : {
         "id" : "q1DcsnV_4d2bk1UeMOUiMJIUOB3SQIr81mIZZ7Z4LMs",
         "name" : "sam@carbon.super",
         "displayName" : "sam"
      }
   }
```
- This introduces the REST API to update the display name of a registered FIDO2 device.
    - /{credentialId}
         - PATCH - Update display name of a device by username and credentialId.
