### PR TITLE
Upgrade yubico-webauthn version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
         <org.apache.cxf.version>3.3.1</org.apache.cxf.version>
         <maven.war.plugin.version>3.2.2</maven.war.plugin.version>
         <maven.build.helper.plugin.version>1.8</maven.build.helper.plugin.version>
-        <orbit.yubico.webauthn.version>1.3.0.wso2v1</orbit.yubico.webauthn.version>
+        <orbit.yubico.webauthn.version>1.3.0.wso2v3</orbit.yubico.webauthn.version>
         <yubico.webauthn.version>1.3.0</yubico.webauthn.version>
     </properties>
 


### PR DESCRIPTION
This PR updates the yubico-webauthn dependency version to the latest version avaible in the wso2 orbit(released from PR[1]).

[1] https://github.com/wso2/orbit/pull/413