### PR TITLE
Delete device associations when user is deleted

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/dao/FIDO2DeviceStoreDAO.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/dao/FIDO2DeviceStoreDAO.java
@@ -784,6 +784,35 @@ public class FIDO2DeviceStoreDAO implements CredentialRepository {
         }
     }
 
+    /**
+     * Delete all device registrations associated to a user.
+     *
+     * @param username      Username.
+     * @param userStoreName Userstore domain.
+     * @param tenantId      Tenant Id.
+     * @throws FIDO2AuthenticatorServerException Error in deleting devices associated to a user.
+     */
+    public void deleteRegistrationsForUser(String username, String userStoreName, int tenantId)
+            throws FIDO2AuthenticatorServerException {
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(); PreparedStatement preparedStatement =
+                connection.prepareStatement(FIDO2AuthenticatorConstants.SQLQueries.
+                        DELETE_REGISTRATIONS_BY_USERNAME_AND_DOMAIN)) {
+            preparedStatement.setString(1, username);
+            preparedStatement.setString(2, userStoreName);
+            preparedStatement.setInt(3, tenantId);
+
+            preparedStatement.execute();
+            if (!connection.getAutoCommit()) {
+                connection.commit();
+            }
+        } catch (SQLException e) {
+            throw new FIDO2AuthenticatorServerException(MessageFormat.format("Could not delete registrations" +
+                    " that is associated to user : {0} in userstore domain : {1} and tenant id : {2}.", username,
+                    userStoreName, tenantId), e);
+        }
+    }
+
     public static boolean isFido2DTOPersistenceSupported() {
 
         if (!isFIDO2DTOPersistenceStatusChecked) {

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/internal/FIDO2AuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/internal/FIDO2AuthenticatorServiceComponent.java
@@ -22,7 +22,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
+import org.wso2.carbon.identity.application.authenticator.fido2.listener.FIDO2DeviceAssociatedUserOperationsListener;
 import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfigListener;
+import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -42,6 +44,8 @@ public class FIDO2AuthenticatorServiceComponent {
 
         try {
             bundleContext.registerService(UserStoreConfigListener.class.getName(), new UserStoreConfigListenerImpl(), null);
+            bundleContext.registerService(UserOperationEventListener.class.getName(),
+                    new FIDO2DeviceAssociatedUserOperationsListener(), null);
         } catch (Exception e){
             log.error("Error registering UserStoreConfigListener ", e);
         }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/listener/FIDO2DeviceAssociatedUserOperationsListener.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/listener/FIDO2DeviceAssociatedUserOperationsListener.java
@@ -43,7 +43,6 @@ public class FIDO2DeviceAssociatedUserOperationsListener extends AbstractIdentit
         if (orderId != IdentityCoreConstants.EVENT_LISTENER_ORDER_ID) {
             return orderId;
         }
-
         return 101;
     }
 
@@ -59,8 +58,6 @@ public class FIDO2DeviceAssociatedUserOperationsListener extends AbstractIdentit
                 throw new UserStoreException("Error in deleting device registration for user " + userName, e);
             }
         }
-
         return true;
     }
-
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/listener/FIDO2DeviceAssociatedUserOperationsListener.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/listener/FIDO2DeviceAssociatedUserOperationsListener.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.fido2.listener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authenticator.fido2.dao.FIDO2DeviceStoreDAO;
+import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorServerException;
+import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+
+/**
+ * This is an implementation of the UserOperationEventListener and this is responsible for operations related to users
+ * that has FIDO2 device associations.
+ */
+public class FIDO2DeviceAssociatedUserOperationsListener extends AbstractIdentityUserOperationEventListener {
+
+    private static final Log log = LogFactory.getLog(FIDO2DeviceAssociatedUserOperationsListener.class);
+
+    @Override
+    public int getExecutionOrderId() {
+
+        int orderId = getOrderId();
+        if (orderId != IdentityCoreConstants.EVENT_LISTENER_ORDER_ID) {
+            return orderId;
+        }
+
+        return 101;
+    }
+
+    @Override
+    public boolean doPostDeleteUser(String userName, UserStoreManager userStoreManager) throws UserStoreException {
+
+        if (FIDO2DeviceStoreDAO.isFido2DTOPersistenceSupported()) {
+            try {
+                String userStoreDomain = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
+                int tenantId = userStoreManager.getTenantId();
+                FIDO2DeviceStoreDAO.getInstance().deleteRegistrationsForUser(userName, userStoreDomain, tenantId);
+            } catch (FIDO2AuthenticatorServerException e) {
+                throw new UserStoreException("Error in deleting device registration for user " + userName, e);
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2AuthenticatorConstants.java
@@ -94,6 +94,9 @@ public class FIDO2AuthenticatorConstants {
 
         public static final String DELETE_REGISTRATION_BY_DOMAIN_AND_TENANT_ID = "DELETE FROM FIDO2_DEVICE_STORE " +
                 "WHERE TENANT_ID = ? AND DOMAIN_NAME = ?";
+
+        public static final String DELETE_REGISTRATIONS_BY_USERNAME_AND_DOMAIN = "DELETE FROM FIDO2_DEVICE_STORE " +
+                "WHERE USER_NAME = ? AND DOMAIN_NAME = ? AND TENANT_ID = ?";
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9154

### Proposed changes in this pull request

With this PR an implementation of the `UserOperationEventListener` is introduced such that when a user is deleted, all associated devices can be deleted by overriding the `doPostDeleteUser` method.