### PR TITLE
Fixing the server issues for FIDO2 conformance

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartRegistrationApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartRegistrationApiServiceImpl.java
@@ -73,7 +73,7 @@ public class StartRegistrationApiServiceImpl extends StartRegistrationApiService
                 return Response.serverError().entity(Util.getErrorDTO(FIDO2Constants.ErrorMessages
                         .ERROR_CODE_START_REGISTRATION, appId)).build();
             }
-        } catch (FIDO2AuthenticatorClientException | UnsupportedEncodingException | FIDO2AuthenticatorServerException e) {
+        } catch (FIDO2AuthenticatorClientException | UnsupportedEncodingException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Client error while starting FIDO2 device registration with appId: " + appId, e);
             }

--- a/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartRegistrationApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartRegistrationApiServiceImpl.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.StartRe
 import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.common.FIDO2Constants;
 import org.wso2.carbon.identity.application.authenticator.fido2.endpoint.common.Util;
 import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorClientException;
+import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorServerException;
 import org.wso2.carbon.identity.application.authenticator.fido2.util.Either;
 import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDOUtil;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
@@ -72,7 +73,7 @@ public class StartRegistrationApiServiceImpl extends StartRegistrationApiService
                 return Response.serverError().entity(Util.getErrorDTO(FIDO2Constants.ErrorMessages
                         .ERROR_CODE_START_REGISTRATION, appId)).build();
             }
-        } catch (FIDO2AuthenticatorClientException | UnsupportedEncodingException e) {
+        } catch (FIDO2AuthenticatorClientException | UnsupportedEncodingException | FIDO2AuthenticatorServerException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Client error while starting FIDO2 device registration with appId: " + appId, e);
             }

--- a/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartUsernamelessRegistrationApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartUsernamelessRegistrationApiServiceImpl.java
@@ -75,7 +75,7 @@ public class StartUsernamelessRegistrationApiServiceImpl extends StartUsernamele
                 return Response.serverError().entity(Util.getErrorDTO
                         (FIDO2Constants.ErrorMessages.ERROR_CODE_START_REGISTRATION, appId)).build();
             }
-        } catch (FIDO2AuthenticatorClientException | UnsupportedEncodingException | FIDO2AuthenticatorServerException e) {
+        } catch (FIDO2AuthenticatorClientException | UnsupportedEncodingException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Client error while starting FIDO2 usernameless device registration with appId: " +
                         appId, e);

--- a/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartUsernamelessRegistrationApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartUsernamelessRegistrationApiServiceImpl.java
@@ -34,6 +34,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 
 import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorClientException;
+import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorServerException;
 import org.wso2.carbon.identity.application.authenticator.fido2.util.Either;
 import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDOUtil;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
@@ -74,7 +75,7 @@ public class StartUsernamelessRegistrationApiServiceImpl extends StartUsernamele
                 return Response.serverError().entity(Util.getErrorDTO
                         (FIDO2Constants.ErrorMessages.ERROR_CODE_START_REGISTRATION, appId)).build();
             }
-        } catch (FIDO2AuthenticatorClientException | UnsupportedEncodingException e) {
+        } catch (FIDO2AuthenticatorClientException | UnsupportedEncodingException | FIDO2AuthenticatorServerException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Client error while starting FIDO2 usernameless device registration with appId: " +
                         appId, e);

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -728,7 +728,8 @@ public class WebAuthnService {
             displayName = FIDO2AuthenticatorServiceComponent.getRealmService().getBootstrapRealm().getUserStoreManager()
                     .getUserClaimValue(user.getUserName(),formattedNameClaimURL, null);
         } catch (UserStoreException e) {
-            throw new FIDO2AuthenticatorServerException("Failed retrieving user claim",e);
+            throw new FIDO2AuthenticatorServerException("Failed retrieving user claim: formattedName for the user:" +
+                    user.toString(), e);
         }
         if (StringUtils.isEmpty(displayName)) {
             displayName = user.toString();

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -144,6 +144,10 @@ public class WebAuthnService {
     /**
      * Triggers FIDO2 start registration flow.
      *
+     * Fido2AuthentcationServerException is newly introduced to this method,
+     * but the method without that exception was not made deprecated since it is not possible to have two
+     * methods with same method signature and different exception handling.
+     *
      * @param origin FIDO2 trusted origin.
      * @return FIDO2 registration request.
      * @throws JsonProcessingException
@@ -171,6 +175,10 @@ public class WebAuthnService {
 
     /**
      * Triggers FIDO2 start usernameless registration flow.
+     *
+     * Fido2AuthentcationServerException is newly introduced to this method,
+     * but the method without that exception was not made deprecated since it is not possible to have two
+     * methods with same method signature and different exception handling.
      *
      * @param origin FIDO2 trusted origin.
      * @return FIDO2 registration request.

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -130,7 +130,7 @@ public class WebAuthnService {
         user.setTenantDomain(CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
 
         PublicKeyCredentialCreationOptions credentialCreationOptions = relyingParty
-                .startRegistration(buildStartRegistrationOptions(user,false));
+                .startRegistration(buildStartRegistrationOptions(user, false));
 
         RegistrationRequest request = new RegistrationRequest(user.toString(), generateRandom(),
                 credentialCreationOptions);
@@ -718,7 +718,7 @@ public class WebAuthnService {
         String formattedNameClaimURL = "http://wso2.org/claims/formattedName";
         try {
             displayName = FIDO2AuthenticatorServiceComponent.getRealmService().getBootstrapRealm().getUserStoreManager()
-                    .getUserClaimValue(user.getUserName(),formattedNameClaimURL, "null");
+                    .getUserClaimValue(user.getUserName(),formattedNameClaimURL, null);
         } catch (UserStoreException e) {
             throw new FIDO2AuthenticatorServerException("Failed retrieving user claim",e);
         }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -155,7 +155,7 @@ public class WebAuthnService {
      * @throws FIDO2AuthenticatorClientException
      */
     public Either<String, FIDO2RegistrationRequest> startFIDO2Registration(@NonNull String origin)
-            throws JsonProcessingException, FIDO2AuthenticatorClientException, FIDO2AuthenticatorServerException {
+            throws JsonProcessingException, FIDO2AuthenticatorClientException {
 
         validateFIDO2TrustedOrigin(origin);
         URL originUrl = getOriginUrl(origin);
@@ -187,7 +187,7 @@ public class WebAuthnService {
      * @throws FIDO2AuthenticatorClientException
      */
     public Either<String, FIDO2RegistrationRequest> startFIDO2UsernamelessRegistration(@NonNull String origin)
-            throws JsonProcessingException, FIDO2AuthenticatorClientException, FIDO2AuthenticatorServerException {
+            throws JsonProcessingException, FIDO2AuthenticatorClientException {
 
         validateFIDO2TrustedOrigin(origin);
         URL originUrl = getOriginUrl(origin);
@@ -702,15 +702,19 @@ public class WebAuthnService {
         return new ByteArray(bytes);
     }
 
-    private StartRegistrationOptions buildStartRegistrationOptions(User user, boolean requireResidentKey)
-            throws FIDO2AuthenticatorServerException {
+    private StartRegistrationOptions buildStartRegistrationOptions(User user, boolean requireResidentKey) throws FIDO2AuthenticatorClientException {
 
-        return StartRegistrationOptions.builder()
-                .user(buildUserIdentity(user))
-                .timeout(Integer.parseInt(userResponseTimeout))
-                .authenticatorSelection(buildAuthenticatorSelection(requireResidentKey))
-                .extensions(RegistrationExtensionInputs.builder().build())
-                .build();
+        try {
+            return StartRegistrationOptions.builder()
+                    .user(buildUserIdentity(user))
+                    .timeout(Integer.parseInt(userResponseTimeout))
+                    .authenticatorSelection(buildAuthenticatorSelection(requireResidentKey))
+                    .extensions(RegistrationExtensionInputs.builder().build())
+                    .build();
+        } catch (FIDO2AuthenticatorServerException e) {
+            throw new FIDO2AuthenticatorClientException("Unable to build StartRegistrationOptions", e);
+        }
+
     }
 
     private AuthenticatorSelectionCriteria buildAuthenticatorSelection(boolean requireResidentKey) {

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -107,6 +107,7 @@ public class WebAuthnService {
     private static ArrayList origins = null;
 
     private static final String userResponseTimeout = IdentityUtil.getProperty("FIDO.UserResponseTimeout");
+    private static final String formattedNameClaimURL = "http://wso2.org/claims/formattedName";
 
     @Deprecated
     /** @deprecated Please use {@link #startFIDO2Registration(String)} instead. */
@@ -723,13 +724,12 @@ public class WebAuthnService {
     private String getUserDisplayName(User user) throws FIDO2AuthenticatorServerException {
 
         String displayName = null;
-        String formattedNameClaimURL = "http://wso2.org/claims/formattedName";
         try {
             displayName = FIDO2AuthenticatorServiceComponent.getRealmService().getBootstrapRealm().getUserStoreManager()
-                    .getUserClaimValue(user.getUserName(),formattedNameClaimURL, null);
+                    .getUserClaimValue(user.getUserName(), formattedNameClaimURL, null);
         } catch (UserStoreException e) {
-            throw new FIDO2AuthenticatorServerException("Failed retrieving user claim: formattedName for the user:" +
-                    user.toString(), e);
+            throw new FIDO2AuthenticatorServerException("Failed retrieving user claim: " + formattedNameClaimURL +
+                    " for the user: " + user.toString(), e);
         }
         if (StringUtils.isEmpty(displayName)) {
             displayName = user.toString();

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -722,6 +722,10 @@ public class WebAuthnService {
         } catch (UserStoreException e) {
             throw new FIDO2AuthenticatorServerException("Failed retrieving user claim",e);
         }
+        if (StringUtils.isEmpty(displayName)) {
+            displayName = user.toString();
+        }
+
         return displayName;
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -145,10 +145,6 @@ public class WebAuthnService {
     /**
      * Triggers FIDO2 start registration flow.
      *
-     * Fido2AuthentcationServerException is newly introduced to this method,
-     * but the method without that exception was not made deprecated since it is not possible to have two
-     * methods with same method signature and different exception handling.
-     *
      * @param origin FIDO2 trusted origin.
      * @return FIDO2 registration request.
      * @throws JsonProcessingException
@@ -176,10 +172,6 @@ public class WebAuthnService {
 
     /**
      * Triggers FIDO2 start usernameless registration flow.
-     *
-     * Fido2AuthentcationServerException is newly introduced to this method,
-     * but the method without that exception was not made deprecated since it is not possible to have two
-     * methods with same method signature and different exception handling.
      *
      * @param origin FIDO2 trusted origin.
      * @return FIDO2 registration request.
@@ -712,7 +704,7 @@ public class WebAuthnService {
                     .extensions(RegistrationExtensionInputs.builder().build())
                     .build();
         } catch (FIDO2AuthenticatorServerException e) {
-            throw new FIDO2AuthenticatorClientException("Unable to build StartRegistrationOptions", e);
+            throw new FIDO2AuthenticatorClientException("Unable to create registration options", e);
         }
 
     }


### PR DESCRIPTION
### Proposed changes in this pull request

This PR,
 - Adds username without tenant domain when building the RP
 - Changes the display name to givenname + lastname
 - Changes the server to DIRECT attestation preference
 - Adds requiredResidentKey: false to startFIDO2Registration flow and requiredResidentKey: true to startFIDO2UsernamelessRegistration flow

Resolves: [#9714 ](https://github.com/wso2/product-is/issues/9714 )


