### PR TITLE
Fix security device registration flow issue

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -625,6 +625,7 @@ public class WebAuthnService {
                 .credentialRepository(userStorage)
                 .origins(new HashSet<String>(origins))
                 .attestationConveyancePreference(AttestationConveyancePreference.DIRECT)
+                .allowUnrequestedExtensions(true)
                 .build();
     }
 


### PR DESCRIPTION
### Purpose

> Currently the device registration flow fails when associating a FIDO2 supported device and prompts an option to retry with an older device.

### Proposed changes in this pull request

> Set **allowUnrequestedExtensions** to true when building the relying party

### GIT Issue
- [https://github.com/wso2/product-is/issues/12026](https://github.com/wso2/product-is/issues/12026)