### PR TITLE
fix(constants): rename fido authn displayName

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/util/FIDOAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/util/FIDOAuthenticatorConstants.java
@@ -26,7 +26,7 @@ public class FIDOAuthenticatorConstants {
     }
 
     public static final String AUTHENTICATOR_NAME = "FIDOAuthenticator";
-    public static final String AUTHENTICATOR_FRIENDLY_NAME = "fido";
+    public static final String AUTHENTICATOR_FRIENDLY_NAME = "Security Key/Biometrics";
     public static final String UNUSED = "unused";
     public static final String AUTHENTICATION_STATUS = "authentication.failed";
     public static final String AUTHENTICATION_ERROR_MESSAGE = "no.registered.device.found";


### PR DESCRIPTION
### Proposed changes in this pull request

- Rename authenticator name `fido` to `Security Key/Biometrics`
