### PR TITLE
Add diagnostic logs to FIDO authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/pom.xml
@@ -23,7 +23,15 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.user.store.configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
@@ -108,6 +116,7 @@
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;
                             version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.utils; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.*;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.user.store.configuration.*;
@@ -115,6 +124,7 @@
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.tenant; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.utils; version="${carbon.kernel.package.import.version.range}",
                             org.xml.sax,
                             com.fasterxml.jackson.core.*; version="${fasterxml.jackson.version}",
                             com.fasterxml.jackson.databind.*; version="${fasterxml.jackson.version}",

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -420,9 +420,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             return Optional.empty();
         }
         try {
-            if (authenticatedUser.getUserId() != null) {
-                return Optional.ofNullable(authenticatedUser.getUserId());
-            }
+            return Optional.of(authenticatedUser.getUserId());
         } catch (UserIdNotFoundException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error while getting the user id from the authenticated user.", e);

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -32,17 +32,23 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Aut
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.fido.dto.FIDOUser;
 import org.wso2.carbon.identity.application.authenticator.fido.u2f.U2FService;
 import org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.fido.util.FIDOUtil;
 import org.wso2.carbon.identity.application.authenticator.fido2.core.WebAuthnService;
+import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.utils.DiagnosticLog;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -51,6 +57,13 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.LogConstants.ActionIDs.PROCESS_AUTHENTICATION_RESPONSE;
+import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.LogConstants.ActionIDs.VALIDATE_FIDO_REQUEST;
+import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.LogConstants.FIDO_AUTH_SERVICE;
 
 /**
  * FIDO U2F Specification based authenticator.
@@ -75,6 +88,16 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                                                  AuthenticationContext context)
             throws AuthenticationFailedException {
 
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    FIDO_AUTH_SERVICE, PROCESS_AUTHENTICATION_RESPONSE);
+            diagnosticLogBuilder.resultMessage("Processing FIDO authentication response.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                    .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                    .inputParams(getApplicationDetails(context));
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
         AuthenticatedUser user = getUsername(context);
         String tokenResponse = request.getParameter("tokenResponse");
         if (tokenResponse != null && !tokenResponse.contains("errorCode")) {
@@ -89,6 +112,21 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                 processFidoAuthenticationResponse(user, appID, tokenResponse);
             }
             context.setSubject(user);
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                        FIDO_AUTH_SERVICE, PROCESS_AUTHENTICATION_RESPONSE);
+                diagnosticLogBuilder.resultMessage("Successfully processed FIDO authentication response.")
+                        .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                        .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                        .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                        .inputParams(getApplicationDetails(context))
+                        .inputParam(LogConstants.InputKeys.USER, LoggerUtils.isLogMaskingEnable ?
+                                LoggerUtils.getMaskedContent(user.getUserName()) : user.getUserName());
+                Optional<String> optionalUserId = getUserId(user);
+                optionalUserId.ifPresent(userId -> diagnosticLogBuilder.inputParam(LogConstants.InputKeys.USER_ID,
+                        userId));
+                LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+            }
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("FIDO authentication failed : " + tokenResponse);
@@ -102,7 +140,16 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
     public boolean canHandle(javax.servlet.http.HttpServletRequest httpServletRequest) {
 
         String tokenResponse = httpServletRequest.getParameter("tokenResponse");
-        return null != tokenResponse;
+        boolean canHandle = null != tokenResponse;
+        if (canHandle && LoggerUtils.isDiagnosticLogsEnabled()) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    FIDO_AUTH_SERVICE, FrameworkConstants.LogConstants.ActionIDs.HANDLE_AUTH_STEP);
+            diagnosticLogBuilder.resultMessage("FIDO authenticator handling the authentication.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS);
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
+        return canHandle;
 
     }
 
@@ -131,6 +178,16 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                                                  AuthenticationContext context)
             throws AuthenticationFailedException {
 
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    FIDO_AUTH_SERVICE, VALIDATE_FIDO_REQUEST);
+            diagnosticLogBuilder.resultMessage("Validate fido authentication request.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                    .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                    .inputParams(getApplicationDetails(context));
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
         AuthenticatedUser user = getUsername(context);
         // Retrieving AppID
         // Origin as appID eg: https://example.com:8080
@@ -139,6 +196,16 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         try {
             String redirectUrl = getRedirectUrl(response, user, appID, getLoginPage(), context);
             response.sendRedirect(redirectUrl);
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                        FIDO_AUTH_SERVICE, VALIDATE_FIDO_REQUEST);
+                diagnosticLogBuilder.resultMessage("FIDO authentication request validation successful.")
+                        .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                        .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                        .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                        .inputParams(getApplicationDetails(context));
+                LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+            }
         } catch (IOException e) {
             throw new AuthenticationFailedException("Could not initiate FIDO authentication request", user, e);
         } catch (URLBuilderException | URISyntaxException e) {
@@ -325,4 +392,42 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         return loginPage;
     }
 
+    /** Add application details to a map.
+     *
+     * @param context AuthenticationContext.
+     * @return Map with application details.
+     */
+    private Map<String, String> getApplicationDetails(AuthenticationContext context) {
+
+        Map<String, String> applicationDetailsMap = new HashMap<>();
+        FrameworkUtils.getApplicationResourceId(context).ifPresent(applicationId ->
+                applicationDetailsMap.put(LogConstants.InputKeys.APPLICATION_ID, applicationId));
+        FrameworkUtils.getApplicationName(context).ifPresent(applicationName ->
+                applicationDetailsMap.put(LogConstants.InputKeys.APPLICATION_NAME,
+                        applicationName));
+        return applicationDetailsMap;
+    }
+
+    /**
+     * Get the user id from the authenticated user.
+     *
+     * @param authenticatedUser AuthenticationContext.
+     * @return User id.
+     */
+    private Optional<String> getUserId(AuthenticatedUser authenticatedUser) {
+
+        if (authenticatedUser == null) {
+            return Optional.empty();
+        }
+        try {
+            if (authenticatedUser.getUserId() != null) {
+                return Optional.ofNullable(authenticatedUser.getUserId());
+            }
+        } catch (UserIdNotFoundException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while getting the user id from the authenticated user.", e);
+            }
+        }
+        return Optional.empty();
+    }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/util/FIDOAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/util/FIDOAuthenticatorConstants.java
@@ -62,5 +62,22 @@ public class FIDOAuthenticatorConstants {
         public static final String DELETE_DEVICE_REGISTRATION_FROM_DOMAIN = "DELETE FROM FIDO_DEVICE_STORE " +
                                                                          "WHERE TENANT_ID = ? AND DOMAIN_NAME = ?";
     }
+
+    /**
+     * Constants related to log management.
+     */
+    public static class LogConstants {
+
+        public static final String FIDO_AUTH_SERVICE = "local-auth-fido";
+
+        /**
+         * Define action IDs for diagnostic logs.
+         */
+        public static class ActionIDs {
+
+            public static final String PROCESS_AUTHENTICATION_RESPONSE = "process-fido-authentication-response";
+            public static final String VALIDATE_FIDO_REQUEST = "validate-fido-authentication-request";
+        }
+    }
 }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorTest.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authenticator.fido.u2f.U2FService;
 import org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.fido2.core.WebAuthnService;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -68,7 +69,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @PrepareForTest({FIDOAuthenticator.class, IdentityUtil.class, MultitenantUtils.class, IdentityTenantUtil.class,
     U2FService.class, AuthenticateResponse.class, ConfigurationFacade.class, FileBasedConfigurationBuilder.class,
-    URLEncoder.class, ServiceURLBuilder.class})
+    URLEncoder.class, ServiceURLBuilder.class, LoggerUtils.class})
 public class FIDOAuthenticatorTest {
 
     private static final String USER_STORE_DOMAIN = "PRIMARY";
@@ -101,6 +102,8 @@ public class FIDOAuthenticatorTest {
         mockStatic(IdentityUtil.class);
         mockStatic(MultitenantUtils.class);
         mockStatic(IdentityTenantUtil.class);
+        mockStatic(LoggerUtils.class);
+        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
     }
 
     private void mockServiceURLBuilder() {

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/pom.xml
@@ -87,6 +87,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
 
         <!--Test Dependencies-->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,11 @@
                 <version>${identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <version>${identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.local.auth.fido</groupId>
                 <artifactId>org.wso2.carbon.identity.application.authenticator.fido2</artifactId>
                 <version>${project.version}</version>
@@ -179,6 +184,12 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.utils</artifactId>
                 <version>${carbon.kernel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -320,7 +331,7 @@
 
     <properties>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <identity.framework.version>5.20.379</identity.framework.version>
+        <identity.framework.version>5.25.262</identity.framework.version>
         <carbon.identity.package.import.version.range>[5.0.0, 7.0.0)</carbon.identity.package.import.version.range>
         <com.yubico.version>0.14.0</com.yubico.version>
         <google.guava.version>32.1.1-jre</google.guava.version>
@@ -337,7 +348,7 @@
         <identity.application.auth.fido.package.export.version>${project.version}</identity.application.auth.fido.package.export.version>
         <axis2.wso2.version>1.6.1.wso2v12</axis2.wso2.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <carbon.kernel.version>4.9.2</carbon.kernel.version>
+        <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <slf4j.version.range>[1.6.1, 2.0.0)</slf4j.version.range>
         <slf4j.api.version>1.7.26</slf4j.api.version>
         <lombok.version>1.18.8</lombok.version>
@@ -354,6 +365,8 @@
         <yubico.webauthn.version>2.4.0</yubico.webauthn.version>
         <orbit.webauthn4j.version>0.21.0.wso2v1</orbit.webauthn4j.version>
         <maven.scr.plugin.version>1.26.0</maven.scr.plugin.version>
+        <org.wso2.carbon.identity.organization.management.core.version>1.0.0
+        </org.wso2.carbon.identity.organization.management.core.version>
         <!--Test Dependencies-->
         <testng.version>6.9.10</testng.version>
         <powermock.version>1.6.5</powermock.version>


### PR DESCRIPTION
### Proposed changes in this pull request
* $subject

### Approach

![image](https://github.com/wso2-enterprise/asgardeo-product/assets/32576163/ceea5959-581e-47aa-b7b2-6962861a2b2d)

Diagnostic logs will be covered the green-colored actions/validations of the authentication process. 
1. Authentication Request Validation
Within each authenticator, the `initiateAuthenticationRequest` method houses the logic for this step. This triggers two diagnostic logs. The first log indicates when authentication validation starts, and the second log shows the result of the validation – whether it's a Success or marked Invalid.

2. Validate Authentication Response
The `processAuthenticationResponse` method handles authentication response validation. Once users are sent to the authentication page and complete the process, the authenticator receives an authentication response, which this method manages. Just like the request validation, this step also generates two diagnostic logs. The first one marks the beginning of response validation, while the second one is only created if the authentication is successful. We've chosen not to include logs for authentication response failures for a couple of reasons:
- Numerous potential failure scenarios across authenticators make adding logs for each too complicated and code-heavy.
- With https://github.com/wso2/carbon-identity-framework/pull/4809, there's a common log in place that covers and reports authentication response failures caused by authenticators.

Additionally, there will be another diagnostic log that will get published from the canHandle() method of the authenticator. The `canHandle` method gets executed each time before the `initiateAuthenticationRequest` and `processAuthenticationResponse` get executed. This log is published as an internal log for our internal developers. The purpose of this log is to verify whether the auth request/response was passed into the authenticator to handle it.