### PR TITLE
Refactor FIDO authenticator to handle the multi attribute login is enabled

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -32,8 +32,8 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Aut
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
-import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.fido.dto.FIDOUser;

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -287,7 +287,8 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             }
         }
 
-        if (user == null) {return webAuthnService.startUsernamelessAuthentication(appID);
+        if (user == null) {
+            return webAuthnService.startUsernamelessAuthentication(appID);
         }
 
         return webAuthnService.startAuthentication(user.getUserName(),

--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
 
     <properties>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <identity.framework.version>5.25.286</identity.framework.version>
+        <identity.framework.version>5.25.287</identity.framework.version>
         <carbon.identity.package.import.version.range>[5.0.0, 7.0.0)</carbon.identity.package.import.version.range>
         <com.yubico.version>0.14.0</com.yubico.version>
         <google.guava.version>32.1.1-jre</google.guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
 
     <properties>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <identity.framework.version>5.25.262</identity.framework.version>
+        <identity.framework.version>5.25.286</identity.framework.version>
         <carbon.identity.package.import.version.range>[5.0.0, 7.0.0)</carbon.identity.package.import.version.range>
         <com.yubico.version>0.14.0</com.yubico.version>
         <google.guava.version>32.1.1-jre</google.guava.version>


### PR DESCRIPTION
### Proposed changes in this pull request
- When multi attribute login is enabled, the user needs to be identified using the relevant attributes.
- We need to resolve the user using the multi attribute user resolving logic.
- Check whether the user is already resolved from previous IDF step.
      - If yes --> don't resolve the user.

### Merge this after 
https://github.com/wso2/carbon-identity-framework/pull/4860