### PR TITLE
Introducing unique user handles for users

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -928,8 +928,10 @@ public class WebAuthnService {
 
     private UserIdentity buildUserIdentity(User user) throws FIDO2AuthenticatorServerException {
 
+        ByteArray userHandle = FIDO2DeviceStoreDAO.getInstance().getUserHandleForUsername(user.toString())
+                .orElseGet(WebAuthnService::generateRandom);
         return UserIdentity.builder().name(user.getUserName()).displayName(getUserDisplayName(user))
-                .id(generateRandom()).build();
+                .id(userHandle).build();
     }
 
     private User getPrivilegedUser() {

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnServiceTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnServiceTest.java
@@ -302,6 +302,8 @@ public class WebAuthnServiceTest {
         StartRegistrationOptions.StartRegistrationOptionsBuilder.MandatoryStages mandatoryStages1 =
                 mock(StartRegistrationOptions.StartRegistrationOptionsBuilder.MandatoryStages.class);
         when(StartRegistrationOptions.builder()).thenReturn(mandatoryStages1);
+        when(fido2DeviceStoreDAO.getUserHandleForUsername(anyString()))
+                .thenReturn(Optional.ofNullable(null));
         when(mandatoryStages1.user(any())).thenReturn(startRegistrationOptionsBuilder);
         when(startRegistrationOptionsBuilder.timeout(anyLong())).thenReturn(startRegistrationOptionsBuilder);
         when(startRegistrationOptionsBuilder.authenticatorSelection(any(AuthenticatorSelectionCriteria.class)))
@@ -328,6 +330,8 @@ public class WebAuthnServiceTest {
         StartRegistrationOptions.StartRegistrationOptionsBuilder.MandatoryStages mandatoryStages1 =
                 mock(StartRegistrationOptions.StartRegistrationOptionsBuilder.MandatoryStages.class);
         when(StartRegistrationOptions.builder()).thenReturn(mandatoryStages1);
+        when(fido2DeviceStoreDAO.getUserHandleForUsername(anyString()))
+                .thenReturn(Optional.ofNullable(null));
         when(mandatoryStages1.user(any())).thenReturn(startRegistrationOptionsBuilder);
         when(startRegistrationOptionsBuilder.timeout(anyLong())).thenReturn(startRegistrationOptionsBuilder);
         when(startRegistrationOptionsBuilder.authenticatorSelection(any(AuthenticatorSelectionCriteria.class)))


### PR DESCRIPTION
### Proposed changes in this pull request

According to the existing implementation each time an user register a new device it will generate a new value for user handle. 
However according to `Yubico java-webauthn-server` documentation it should use the existing value instead of generating a new value. With this PR that behaviour will be fixed, a new user handle will be generated only if there is no existing user handle for the given user.

### Related Git Issue

- https://github.com/wso2/product-is/issues/16443

