### PR TITLE
Fix Google federation progressive enrolment

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -107,6 +107,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -948,7 +949,10 @@ public class WebAuthnService {
         String claimValue;
         try {
             UserStoreManager userStoreManager = getUserStoreManager(user);
-            claimValue = userStoreManager.getUserClaimValue(user.getUserName(), claimURL, null);
+            // When use Google federated progressive enrollment email type user name become tenant qualified username.
+            // So adding MultitenantUtils.getTenantAwareUsername to pass tenantAwareUsername
+            claimValue = userStoreManager.getUserClaimValue(MultitenantUtils.getTenantAwareUsername(user.getUserName())
+                    , claimURL, null);
         } catch (UserStoreException e) {
             throw new FIDO2AuthenticatorServerException(
                     "Failed retrieving user claim: " + claimURL + " for the user: " + user, e);


### PR DESCRIPTION
### Proposed changes in this pull request
Fixes https://github.com/wso2/product-is/issues/18774

### Root cause:
When doing JIT provisioning from google, User created with email type username, But the deployment is alphaNumeric username configured.

During the Passkey Enrollment flow we [preprocess Username to get mappedLocalUsername](https://github.com/wso2-extensions/identity-local-auth-fido/blob/054f03770a7b386650c3a3d87327755e2084cb74/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java#L1170) which will add carbon.super (the tenant domain) to the username.

Later IS try to StartRegistrationOptions, IS tries to resolve the user's displayname. For that it p[asses the tenant qualified username to userstore](https://github.com/wso2-extensions/identity-local-auth-fido/blob/c402b2c5cdb39c20110bc86b4d482c6f3750913a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java#L951) which results  user not found.

<img width="1627" alt="Screenshot 2024-01-24 at 15 32 28" src="https://github.com/wso2/product-is/assets/25488962/dda7a097-37b3-4f33-8fa0-ae2ee37bae1f">


I tried to remove the preprocess procedure, but encountered following issue.

If we remove the preprocess procedure, retrieving user using username in [Here](https://github.com/wso2-extensions/identity-local-auth-fido/blob/7f4bfb7f49ac3dbd0f55528fb8b9d66c6a3710f6/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/dao/FIDO2DeviceStoreDAO.java#L424) will fail cause [we are trying to resolve tenant domain from the username](https://github.com/wso2/carbon-identity-framework/blob/e5c55dfd9dc0ca4d1a46ee48c66d1124e796724e/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/User.java#L198).

Ideal solution should be improving framework User Model to retrieve user from username and tenant domain passed separately. But due to above issue, I added a workaround by calling MultitenantUtils. getTenantAware username to pass tenantless username to userstore to retrieve the user.