### PR TITLE
Add NPE check for username in IDF Initiated flow

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -625,7 +625,11 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         // resolved by retrieving the collected username.
         if ((user == null) && isFidoAsFirstFactor(context) && isIDFInitiatedFromAuthenticator(context)) {
             String username = retrievePersistedUsername(context);
-            user = resolveUserFromUsername(username, context);
+            // Users have the option to restart the flow from the 1st step by choosing a different option.
+            // In such cases, user name will be null, hence the process is directed to query username.
+            if (StringUtils.isNotBlank(username)) {
+                user = resolveUserFromUsername(username, context);
+            }
         }
 
         //If the user is federated, retrieve the just-in-time provisioned federated user.


### PR DESCRIPTION
### Proposed changes in this pull request
Users have the option to restart the flow from the 1st step by choosing a different option. In such cases, user name will be null, hence the process is directed to query username.

Related Issue: https://github.com/wso2/product-is/issues/19110

UserNameLess Authentication
https://github.com/wso2-extensions/identity-local-auth-fido/assets/25488962/8f26dbf5-6a73-4803-b7c9-32ed5d3930fb

PassiveEnrollemnt
https://github.com/wso2-extensions/identity-local-auth-fido/assets/25488962/ab464a6c-f923-47ab-b835-71368e711059

Username Queried after clicking choose different option (Bugged case)

https://github.com/wso2-extensions/identity-local-auth-fido/assets/25488962/4ea2148a-e732-4b5c-8e0c-2a491c655c57

2FA with clicking choose different option

https://github.com/wso2-extensions/identity-local-auth-fido/assets/25488962/6b0033ed-c3d9-4b38-b7cc-bf9ec7567332

