### PR TITLE
Provide API support to configure fido trusted origins

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartRegistrationApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartRegistrationApiServiceImpl.java
@@ -90,6 +90,10 @@ public class StartRegistrationApiServiceImpl extends StartRegistrationApiService
             LOG.error("JsonProcessingException while starting FIDO2 device registration with appId: " + appId, e);
             return Response.serverError().entity(Util.getErrorDTO(FIDO2Constants.ErrorMessages
                             .ERROR_CODE_START_REGISTRATION, appId)).build();
+        } catch (FIDO2AuthenticatorServerException e) {
+            LOG.error("Server error while starting FIDO2 device registration with appId: " + appId, e);
+            return Response.serverError().entity(Util.getErrorDTO(FIDO2Constants.ErrorMessages
+                    .ERROR_CODE_START_REGISTRATION, appId)).build();
         }
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartUsernamelessRegistrationApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/endpoint/impl/StartUsernamelessRegistrationApiServiceImpl.java
@@ -87,6 +87,11 @@ public class StartUsernamelessRegistrationApiServiceImpl extends StartUsernamele
                     appId, e);
             return Response.serverError().entity(Util.getErrorDTO
                     (FIDO2Constants.ErrorMessages.ERROR_CODE_START_REGISTRATION, appId)).build();
+        } catch (FIDO2AuthenticatorServerException e) {
+            LOG.error("Server error while starting FIDO2 usernameless device registration with appId: " +
+                    appId, e);
+            return Response.serverError().entity(Util.getErrorDTO
+                    (FIDO2Constants.ErrorMessages.ERROR_CODE_START_REGISTRATION, appId)).build();
         }
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -839,6 +839,9 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             setAuthenticatorMessageToContext(message, e.getErrorCode(), context);
             throw new AuthenticationFailedException("FIDO2 trusted origin: " + appID + " sent in the request is " +
                     "invalid.");
+        } catch (FIDO2AuthenticatorServerException e) {
+            throw new AuthenticationFailedException("A system error occurred while starting fido registration for " +
+                    "the appId :" + appID);
         }
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -582,8 +582,7 @@ public class WebAuthnService {
         } catch (IOException e) {
             throw new AuthenticationFailedException("Assertion failed! Failed to decode response object.", e);
         } catch (FIDO2AuthenticatorServerException e) {
-            throw new AuthenticationFailedException("Server error when building relying party for authentication " +
-                    "of username: ", username, e);
+            throw new AuthenticationFailedException("Server error when building relying party for authentication.", e);
         }
         if (request == null) {
             throw new AuthenticationFailedException("Assertion failed! No such assertion in progress.");
@@ -1294,9 +1293,12 @@ public class WebAuthnService {
 
         String[] fidoTrustedOrigins = null;
         try {
-            fidoTrustedOrigins = FIDO2AuthenticatorServiceDataHolder.getInstance().getConfigurationManager()
+            String trustedOriginsFromDB = FIDO2AuthenticatorServiceDataHolder.getInstance().getConfigurationManager()
                     .getAttribute(FIDO_CONFIG_RESOURCE_TYPE_NAME, FIDO2_CONNECTOR_CONFIG_RESOURCE_NAME,
-                            FIDO2_CONFIG_TRUSTED_ORIGIN_ATTRIBUTE_NAME).getValue().split(",");
+                            FIDO2_CONFIG_TRUSTED_ORIGIN_ATTRIBUTE_NAME).getValue();
+            if (StringUtils.isNotBlank(trustedOriginsFromDB)) {
+                fidoTrustedOrigins = trustedOriginsFromDB.split(",");
+            }
         } catch (ConfigurationManagementException e) {
             if (Objects.equals(e.getErrorCode(), ERROR_CODE_ATTRIBUTE_DOES_NOT_EXISTS.getCode())) {
                 if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2AuthenticatorConstants.java
@@ -62,10 +62,12 @@ public class FIDO2AuthenticatorConstants {
 
     public static final String FIDO_CONFIG_RESOURCE_TYPE_NAME = "fido-config";
     public static final String FIDO2_CONFIG_RESOURCE_NAME = "fido2-validations";
+    public static final String FIDO2_CONNECTOR_CONFIG_RESOURCE_NAME = "fido-connector";
     public static final String FIDO2_CONFIG_ATTESTATION_VALIDATION_ATTRIBUTE_NAME = "AttestationValidation.Enable";
     public static final boolean FIDO2_CONFIG_ATTESTATION_VALIDATION_DEFAULT_VALUE = true;
     public static final String FIDO2_CONFIG_MDS_VALIDATION_ATTRIBUTE_NAME = "MDSValidation.Enable";
     public static final boolean FIDO2_CONFIG_MDS_VALIDATION_DEFAULT_VALUE = false;
+    public static final String FIDO2_CONFIG_TRUSTED_ORIGIN_ATTRIBUTE_NAME = "FIDO2TrustedOrigins";
 
     /**
      * SQL Queries class for FIDO2 Authenticator Constants Util class.

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnServiceTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnServiceTest.java
@@ -631,7 +631,8 @@ public class WebAuthnServiceTest {
 
     @Test(description = "Test case for validateFIDO2TrustedOrigin() method",
             dataProvider = "validateFIDO2TrustedOriginDataProvider")
-    public void testValidateFIDO2TrustedOrigin(String origin, String trustedOrigins, boolean validationSuccess) throws Exception {
+    public void testValidateFIDO2TrustedOrigin(String origin, String trustedOrigins, boolean validationSuccess)
+            throws Exception {
 
         when(configurationManager.getAttribute(FIDO_CONFIG_RESOURCE_TYPE_NAME, FIDO2_CONNECTOR_CONFIG_RESOURCE_NAME,
                 FIDO2_CONFIG_TRUSTED_ORIGIN_ATTRIBUTE_NAME)).thenReturn(

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnServiceTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnServiceTest.java
@@ -81,6 +81,7 @@ import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2Authen
 import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDOUtil;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -121,8 +122,10 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 import static org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2AuthenticatorConstants.FIDO2_CONFIG_ATTESTATION_VALIDATION_ATTRIBUTE_NAME;
 import static org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2AuthenticatorConstants.FIDO2_CONFIG_MDS_VALIDATION_ATTRIBUTE_NAME;
+import static org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2AuthenticatorConstants.FIDO2_CONFIG_TRUSTED_ORIGIN_ATTRIBUTE_NAME;
 import static org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2AuthenticatorConstants.FIDO2_CONFIG_RESOURCE_NAME;
 import static org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2AuthenticatorConstants.FIDO_CONFIG_RESOURCE_TYPE_NAME;
+import static org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2AuthenticatorConstants.FIDO2_CONNECTOR_CONFIG_RESOURCE_NAME;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_ID;
 
@@ -214,7 +217,7 @@ public class WebAuthnServiceTest {
     private AssertionResult assertionResult;
 
     @BeforeMethod
-    public void setUp() throws UserStoreException, IOException, FIDO2AuthenticatorServerException {
+    public void setUp() throws UserStoreException, IOException, FIDO2AuthenticatorServerException, ConfigurationManagementException {
 
         prepareResources();
         initMocks(this);
@@ -230,6 +233,9 @@ public class WebAuthnServiceTest {
         when(FIDO2DeviceStoreDAO.getInstance()).thenReturn(fido2DeviceStoreDAO);
         trustedOrigins.add(ORIGIN);
         identityConfig.put(FIDO2AuthenticatorConstants.TRUSTED_ORIGINS, trustedOrigins);
+        when(configurationManager.getAttribute(FIDO_CONFIG_RESOURCE_TYPE_NAME, FIDO2_CONNECTOR_CONFIG_RESOURCE_NAME,
+                FIDO2_CONFIG_TRUSTED_ORIGIN_ATTRIBUTE_NAME)).thenReturn(
+                new Attribute(FIDO2_CONFIG_TRUSTED_ORIGIN_ATTRIBUTE_NAME, (String.join(",",trustedOrigins))));
         mockStatic(IdentityConfigParser.class);
         when(IdentityConfigParser.getInstance()).thenReturn(identityConfigParser);
         when(identityConfigParser.getConfiguration()).thenReturn(identityConfig);


### PR DESCRIPTION
This PR adds the changes needed to load fido trusted origins from the `IDN_CONFIG_ATTRIBUTE` db table so that the config management api can be used to set trusted origins to the fido connector.