### PR TITLE
Add debug logs to identify assertion failure reasons.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -1062,6 +1062,9 @@ public class WebAuthnService {
             return relyingParty.finishAssertion(FinishAssertionOptions.builder()
                     .request(request).response(credential).build());
         } catch (AssertionFailedException e) {
+            if(log.isDebugEnabled()) {
+                log.debug("Assertion failure exception.", e);
+            }
             throw new AuthenticationFailedException("Assertion failed while finishing the assertion to retrieve the " +
                     "assertion result.", e);
         } catch (Exception e) {


### PR DESCRIPTION
Add a debug log after assertion failure during fido authentication to identify failure reasons such as not addign fido trusted origins.