### PR TITLE
Bump jackson libraries versions to 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -421,8 +421,8 @@
         <identity.extension.utils.import.version.range>[1.0.8,2.0.0)</identity.extension.utils.import.version.range>
         <com.yubico.version>0.14.0</com.yubico.version>
         <google.guava.version>33.0.0-jre</google.guava.version>
-        <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
-        <jackson-databind.version>2.16.1</jackson-databind.version>
+        <fasterxml.jackson.version>2.17.2</fasterxml.jackson.version>
+        <jackson-databind.version>2.17.2</jackson-databind.version>
         <bcprov.version>1.49.0.wso2v2</bcprov.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>


### PR DESCRIPTION
### Proposed changes in this pull request

The lib folder of the product packs the Jackson library 2.17.2 version but the Jackson version of the OSGI bundle which resides in the plugin folder is still in 2.16.1 version which cause some class loader issues where workflow feature doesn't work as expected.

Having same version fix the problem. The Jackson version upgrade has been done for WSO2 updated products also hence upgrading to Jackson 2.17.2 shouldn't be an issue.

### Related Issues
- https://github.com/wso2/product-is/issues/22466
