### PR TITLE
Fix authenticated user resolving logic in passkey

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Adopt JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: "8"
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-m2
         with:

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -280,7 +280,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
     private void redirectToPasskeyEnrollmentConsentPage(HttpServletResponse response, AuthenticationContext context)
             throws AuthenticationFailedException {
 
-        AuthenticatedUser user = getUsername(context);
+        AuthenticatedUser user = getAuthenticatedUser(context);
         if (user == null) {
             throw new AuthenticationFailedException("Passkey enrollment failed!. Cannot proceed further without " +
                     "identifying the user");
@@ -301,7 +301,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
     private void redirectToPasskeysExistenceStatusPage(HttpServletResponse response, AuthenticationContext context,
                                                        boolean isPasskeysExist) throws AuthenticationFailedException {
 
-        AuthenticatedUser user = getUsername(context);
+        AuthenticatedUser user = getAuthenticatedUser(context);
         if (user == null) {
             throw new AuthenticationFailedException("Passkeys existence status display failed!. Cannot redirect the " +
                     "user to the passkeys existence status display page without identifying the user.");
@@ -323,7 +323,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
     private void initiatePasskeyEnrollmentRequest(HttpServletRequest request, HttpServletResponse response,
                                                   AuthenticationContext context) throws AuthenticationFailedException {
 
-        AuthenticatedUser user = getUsername(context);
+        AuthenticatedUser user = getAuthenticatedUser(context);
         if (user == null) {
             throw new AuthenticationFailedException("Passkey enrollment failed!. Cannot proceed further without " +
                     "identifying the user");
@@ -419,7 +419,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                                                     AuthenticationContext context)
             throws AuthenticationFailedException {
 
-        AuthenticatedUser user = getUsername(context);
+        AuthenticatedUser user = getAuthenticatedUser(context);
         if (user == null) {
             throw new AuthenticationFailedException("Passkey enrollment failed! Cannot proceed further without " +
                     "identifying the user");
@@ -480,7 +480,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                     .inputParams(getApplicationDetails(context));
             LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
         }
-        AuthenticatedUser user = getUsername(context);
+        AuthenticatedUser user = getAuthenticatedUser(context);
         //If the user is federated, retrieve the just-in-time provisioned federated user.
         if ((user != null) && user.isFederatedUser()) {
             AuthenticatedUser provisionedFederateUser = getProvisionedFederatedUser(user, context);
@@ -620,7 +620,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                     .inputParams(getApplicationDetails(context));
             LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
         }
-        AuthenticatedUser user = getUsername(context);
+        AuthenticatedUser user = getAuthenticatedUser(context);
 
         // If the username was initially obtained through the passkey identifier first page, the user needs to be
         // resolved by retrieving the collected username.
@@ -922,28 +922,6 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             appID = getAuthenticatorConfig().getParameterMap().get(FIDOAuthenticatorConstants.APP_ID);
         }
         return appID;
-    }
-
-    private AuthenticatedUser getUsername(AuthenticationContext context) {
-
-        //username from authentication context.
-        AuthenticatedUser authenticatedUser = null;
-        for (int i = 1; i <= context.getSequenceConfig().getStepMap().size(); i++) {
-            StepConfig stepConfig = context.getSequenceConfig().getStepMap().get(i);
-            if (stepConfig.getAuthenticatedUser() != null) {
-                authenticatedUser = stepConfig.getAuthenticatedUser();
-                if (authenticatedUser.getUserStoreDomain() == null) {
-                    authenticatedUser.setUserStoreDomain(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
-                }
-
-                if (log.isDebugEnabled()) {
-                    log.debug("username :" + authenticatedUser.toString());
-                }
-                break;
-            }
-        }
-
-        return authenticatedUser;
     }
 
     private String getLoginPage() {

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -990,8 +990,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         for (StepConfig stepConfig : stepConfigMap.values()) {
             AuthenticatedUser authenticatedUserInStepConfig = stepConfig.getAuthenticatedUser();
             if (stepConfig.isSubjectAttributeStep() && authenticatedUserInStepConfig != null) {
-                authenticatedUser = new AuthenticatedUser(stepConfig.getAuthenticatedUser());
-                break;
+                return new AuthenticatedUser(stepConfig.getAuthenticatedUser());
             }
         }
         if (context.getLastAuthenticatedUser() != null && context.getLastAuthenticatedUser().getUserName() != null) {

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -792,8 +792,8 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         if (FrameworkUtils.isPreviousIdPAuthenticationFlowHandler(context)) {
             boolean isUserResolved = FrameworkUtils.getIsUserResolved(context);
             if (!isUserResolved && user != null) {
-                String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(user.getUserName());
-                String tenantDomain = MultitenantUtils.getTenantDomain(user.getUserName());
+                String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(user.toFullQualifiedUsername());
+                String tenantDomain = MultitenantUtils.getTenantDomain(user.toFullQualifiedUsername());
                 ResolvedUserResult resolvedUserResult = FrameworkUtils.
                         processMultiAttributeLoginIdentification(tenantAwareUsername, tenantDomain);
                 if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -985,7 +985,6 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
      */
     private AuthenticatedUser getAuthenticatedUser(AuthenticationContext context) {
 
-        AuthenticatedUser authenticatedUser = null;
         Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
         for (StepConfig stepConfig : stepConfigMap.values()) {
             AuthenticatedUser authenticatedUserInStepConfig = stepConfig.getAuthenticatedUser();
@@ -994,9 +993,9 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             }
         }
         if (context.getLastAuthenticatedUser() != null && context.getLastAuthenticatedUser().getUserName() != null) {
-            authenticatedUser = context.getLastAuthenticatedUser();
+            return context.getLastAuthenticatedUser();
         }
-        return authenticatedUser;
+        return null;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorTest.java
@@ -249,10 +249,13 @@ public class FIDOAuthenticatorTest {
                 .createLocalAuthenticatedUserFromSubjectIdentifier(USERNAME);
         authenticatedUser.setFederatedUser(false);
         authenticatedUser.setUserName(USERNAME);
+        authenticatedUser.setUserStoreDomain(USER_STORE_DOMAIN);
+        authenticatedUser.setTenantDomain(SUPER_TENANT_DOMAIN);
 
         StepConfig stepConfig = new StepConfig();
         stepConfig.setAuthenticatorList(authenticatorList);
         stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
         Map<Integer, StepConfig> stepMap = new HashMap<>();
         stepMap.put(1, stepConfig);
         SequenceConfig sequenceConfig = new SequenceConfig();
@@ -285,10 +288,12 @@ public class FIDOAuthenticatorTest {
         authenticatedUser.setFederatedUser(false);
         authenticatedUser.setUserName(USERNAME);
         authenticatedUser.setTenantDomain(SUPER_TENANT_DOMAIN);
+        authenticatedUser.setUserStoreDomain(USER_STORE_DOMAIN);
 
         StepConfig stepConfig = new StepConfig();
         stepConfig.setAuthenticatorList(authenticatorList);
         stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
         Map<Integer, StepConfig> stepMap = new HashMap<>();
         stepMap.put(1, stepConfig);
         SequenceConfig sequenceConfig = new SequenceConfig();
@@ -430,10 +435,12 @@ public class FIDOAuthenticatorTest {
         authenticatedUser.setFederatedUser(false);
         authenticatedUser.setUserName(USERNAME);
         authenticatedUser.setTenantDomain(SUPER_TENANT_DOMAIN);
+        authenticatedUser.setUserStoreDomain(USER_STORE_DOMAIN);
 
         StepConfig stepConfig = new StepConfig();
         stepConfig.setAuthenticatorList(authenticatorList);
         stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
         Map<Integer, StepConfig> stepMap = new HashMap<>();
         stepMap.put(1, stepConfig);
         SequenceConfig sequenceConfig = new SequenceConfig();


### PR DESCRIPTION
### Proposed changes in this pull request
The existing getUsername method incorrectly resolved the authenticated user by always taking it from the first step configuration where an authenticated user was present. This could lead to an incorrect user being identified if subsequent authentication steps modified or determined the actual subject.

This PR rectifies this behavior by changing getUsername to utilize the getAuthenticatedUser method, ensuring a more accurate authenticated user.

### Concern:
In the getAuthenticatedUser method, the context.getLastAuthenticatedUser() is given precedence over the user identified from the subjectAttributeStep. This pattern of prioritizing lastAuthenticatedUser is present in other authenticators as well.

```
private AuthenticatedUser getAuthenticatedUser(AuthenticationContext context) {

        AuthenticatedUser authenticatedUser = null;
        Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
        for (StepConfig stepConfig : stepConfigMap.values()) {
            AuthenticatedUser authenticatedUserInStepConfig = stepConfig.getAuthenticatedUser();
            if (stepConfig.isSubjectAttributeStep() && authenticatedUserInStepConfig != null) {
                authenticatedUser = new AuthenticatedUser(stepConfig.getAuthenticatedUser());
                break;
            }
        }
        if (context.getLastAuthenticatedUser() != null && context.getLastAuthenticatedUser().getUserName() != null) {
            authenticatedUser = context.getLastAuthenticatedUser();
        }
        return authenticatedUser;
    }
```

This logic was updated to give the precedence to the subject identifier step.

### Related Issues
- https://github.com/wso2/product-is/issues/24154