### PR TITLE
Remove the redundant test run in PR buider.

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -40,7 +40,7 @@ jobs:
         run: mvn clean install -U -B
 
       - name: Generate coverage report
-        run: mvn test jacoco:report
+        run: mvn jacoco:report
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
### Description
- This pull request makes a small adjustment to the `.github/workflows/pr-builder.yml` file by modifying the command used to generate the coverage report.
- The change removes the `mvn test` step, leaving only `mvn jacoco:report` to streamline the process.
- This will reduce the average 7 minute builder running time to 5 minutes.