### PR TITLE
Keep the passkey credential in the flow context until the user registration

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/pom.xml
@@ -95,6 +95,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.flow.execution.engine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.flow.mgt</artifactId>
+        </dependency>
 
         <!--Test Dependencies-->
         <dependency>
@@ -179,6 +183,8 @@
                             org.wso2.carbon.identity.configuration.mgt.core.*;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.flow.execution.engine.*;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.flow.mgt;
                             version="${carbon.identity.package.import.version.range}",
                         </Import-Package>
                         <Export-Package>

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/FIDO2Executor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/FIDO2Executor.java
@@ -151,7 +151,8 @@ public class FIDO2Executor implements Executor {
         return response;
     }
 
-    private String getUserDisplayName(FlowExecutionContext flowExecutionContext) throws FIDO2AuthenticatorServerException {
+    private String getUserDisplayName(FlowExecutionContext flowExecutionContext)
+            throws FIDO2AuthenticatorServerException {
 
         String displayName = (String) flowExecutionContext.getFlowUser().getClaim(DISPLAY_NAME_CLAIM_URL);
         // If the displayName is not available, build the displayName with firstName and lastName.

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/RegistrationFlowCompletionListener.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/RegistrationFlowCompletionListener.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.fido2.executor;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yubico.fido.metadata.MetadataBLOBPayloadEntry;
+import com.yubico.webauthn.RegisteredCredential;
+import com.yubico.webauthn.data.UserIdentity;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authenticator.fido2.dao.FIDO2DeviceStoreDAO;
+import org.wso2.carbon.identity.application.authenticator.fido2.dto.FIDO2CredentialRegistration;
+import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorServerException;
+import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2ExecutorConstants;
+import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDOUtil;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.flow.execution.engine.Constants;
+import org.wso2.carbon.identity.flow.execution.engine.listener.AbstractFlowExecutionListener;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionStep;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Flow execution listener to handle FIDO2 registration flow completion.
+ * This listener is triggered when the registration flow is completed.
+ */
+public class RegistrationFlowCompletionListener extends AbstractFlowExecutionListener {
+
+    private static final Log LOG = LogFactory.getLog(RegistrationFlowCompletionListener.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public int getExecutionOrderId() {
+
+        return 5;
+    }
+
+    @Override
+    public int getDefaultOrderId() {
+
+        return 5;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+
+    @Override
+    public boolean doPostExecute(FlowExecutionStep step, FlowExecutionContext context) {
+
+        if (FIDOUtil.isRegistrationFlow(context) && Constants.STATUS_COMPLETE.equals(step.getFlowStatus())) {
+            Object registrationRequestObj = context.getProperty(FIDO2ExecutorConstants.CREDENTIAL_REGISTRATION);
+            if (registrationRequestObj == null) {
+                return true;
+            }
+            Map<String, Object> credentialRegistration = mapper.convertValue(registrationRequestObj,
+                    new TypeReference<Map<String, Object>>() {
+                    });
+            try {
+                FIDO2DeviceStoreDAO.getInstance().addFIDO2RegistrationByUsername(context.getFlowUser().getUsername(),
+                        buildFromMap(credentialRegistration));
+            } catch (FIDO2AuthenticatorServerException e) {
+                LOG.error("Error while storing FIDO2 registration for user: " +
+                        LoggerUtils.getMaskedContent(context.getFlowUser().getUsername()) + " in flow: " +
+                        context.getContextIdentifier(), e);
+            }
+        }
+        return true;
+    }
+
+    private static FIDO2CredentialRegistration buildFromMap(Map<String, Object> map) {
+
+        Object credentialObj = map.get(FIDO2ExecutorConstants.CREDENTIAL);
+        Object userIdentityObj = map.get(FIDO2ExecutorConstants.RegistrationConstants.USER_IDENTITY);
+
+        RegisteredCredential credential = mapper.convertValue(credentialObj, RegisteredCredential.class);
+        UserIdentity userIdentity = mapper.convertValue(userIdentityObj, UserIdentity.class);
+
+        Optional<String> credentialNickname = Optional.ofNullable((String) map.get(FIDO2ExecutorConstants.RegistrationConstants.CREDENTIAL_NICKNAME));
+        Optional<MetadataBLOBPayloadEntry> attestationMetadata = Optional.ofNullable(
+                mapper.convertValue(map.get(FIDO2ExecutorConstants.RegistrationConstants.ATTESTATION_METADATA), MetadataBLOBPayloadEntry.class));
+
+        long signatureCount = map.get(FIDO2ExecutorConstants.RegistrationConstants.SIGNATURE_COUNT) != null ? ((Number) map.get(FIDO2ExecutorConstants.RegistrationConstants.SIGNATURE_COUNT)).longValue() : 0;
+        String displayName = (String) map.get(FIDO2ExecutorConstants.RegistrationConstants.DISPLAY_NAME);
+        boolean isUsernamelessSupported = Boolean.TRUE.equals(map.get(FIDO2ExecutorConstants.RegistrationConstants.IS_USERNAMELESS_SUPPORTED));
+
+        Instant registrationTime = null;
+        if (map.get(FIDO2ExecutorConstants.RegistrationConstants.REGISTRATION_TIME) != null) {
+            registrationTime = Instant.parse((String) map.get(FIDO2ExecutorConstants.RegistrationConstants.REGISTRATION_TIME));
+        }
+
+        FIDO2CredentialRegistration registration = FIDO2CredentialRegistration.builder()
+                .signatureCount(signatureCount)
+                .userIdentity(userIdentity)
+                .credentialNickname(credentialNickname)
+                .credential(credential)
+                .attestationMetadata(attestationMetadata)
+                .displayName(displayName)
+                .isUsernamelessSupported(isUsernamelessSupported)
+                .build();
+
+        if (registrationTime != null) {
+            registration = registration.withRegistrationTime(registrationTime);
+        }
+        return registration;
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/RegistrationFlowCompletionListener.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/RegistrationFlowCompletionListener.java
@@ -98,17 +98,22 @@ public class RegistrationFlowCompletionListener extends AbstractFlowExecutionLis
         RegisteredCredential credential = mapper.convertValue(credentialObj, RegisteredCredential.class);
         UserIdentity userIdentity = mapper.convertValue(userIdentityObj, UserIdentity.class);
 
-        Optional<String> credentialNickname = Optional.ofNullable((String) map.get(FIDO2ExecutorConstants.RegistrationConstants.CREDENTIAL_NICKNAME));
+        Optional<String> credentialNickname = Optional.ofNullable((String)
+                map.get(FIDO2ExecutorConstants.RegistrationConstants.CREDENTIAL_NICKNAME));
         Optional<MetadataBLOBPayloadEntry> attestationMetadata = Optional.ofNullable(
-                mapper.convertValue(map.get(FIDO2ExecutorConstants.RegistrationConstants.ATTESTATION_METADATA), MetadataBLOBPayloadEntry.class));
+                mapper.convertValue(map.get(FIDO2ExecutorConstants.RegistrationConstants.ATTESTATION_METADATA),
+                        MetadataBLOBPayloadEntry.class));
 
-        long signatureCount = map.get(FIDO2ExecutorConstants.RegistrationConstants.SIGNATURE_COUNT) != null ? ((Number) map.get(FIDO2ExecutorConstants.RegistrationConstants.SIGNATURE_COUNT)).longValue() : 0;
+        long signatureCount = map.get(FIDO2ExecutorConstants.RegistrationConstants.SIGNATURE_COUNT) != null ?
+                ((Number) map.get(FIDO2ExecutorConstants.RegistrationConstants.SIGNATURE_COUNT)).longValue() : 0;
         String displayName = (String) map.get(FIDO2ExecutorConstants.RegistrationConstants.DISPLAY_NAME);
-        boolean isUsernamelessSupported = Boolean.TRUE.equals(map.get(FIDO2ExecutorConstants.RegistrationConstants.IS_USERNAMELESS_SUPPORTED));
+        boolean isUsernamelessSupported = Boolean.TRUE.equals(
+                map.get(FIDO2ExecutorConstants.RegistrationConstants.IS_USERNAMELESS_SUPPORTED));
 
         Instant registrationTime = null;
         if (map.get(FIDO2ExecutorConstants.RegistrationConstants.REGISTRATION_TIME) != null) {
-            registrationTime = Instant.parse((String) map.get(FIDO2ExecutorConstants.RegistrationConstants.REGISTRATION_TIME));
+            registrationTime = Instant.parse((String)
+                    map.get(FIDO2ExecutorConstants.RegistrationConstants.REGISTRATION_TIME));
         }
 
         FIDO2CredentialRegistration registration = FIDO2CredentialRegistration.builder()

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/internal/FIDO2AuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/internal/FIDO2AuthenticatorServiceComponent.java
@@ -29,11 +29,13 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.authenticator.fido2.executor.FIDO2Executor;
+import org.wso2.carbon.identity.application.authenticator.fido2.executor.RegistrationFlowCompletionListener;
 import org.wso2.carbon.identity.application.authenticator.fido2.listener.FIDO2DeviceAssociatedUserOperationsListener;
 import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDOUtil;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.flow.execution.engine.graph.Executor;
+import org.wso2.carbon.identity.flow.execution.engine.listener.FlowExecutionListener;
 import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfigListener;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -63,6 +65,7 @@ public class FIDO2AuthenticatorServiceComponent {
             bundleContext.registerService(UserOperationEventListener.class.getName(),
                     new FIDO2DeviceAssociatedUserOperationsListener(), null);
             bundleContext.registerService(Executor.class.getName(), new FIDO2Executor(), null);
+            bundleContext.registerService(FlowExecutionListener.class, new RegistrationFlowCompletionListener(), null);
         } catch (Exception e) {
             log.error("Error registering UserStoreConfigListener ", e);
         }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2ExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2ExecutorConstants.java
@@ -32,9 +32,25 @@ public class FIDO2ExecutorConstants {
     public static final String REQUEST_ID_CONTEXT_KEY = "webAuthnRequestId";
     public static final String CREDENTIAL = "credential";
     public static final String CREDENTIAL_ID = "credentialId";
+    public static final String CREDENTIAL_REGISTRATION = "credentialRegistration";
     public static final String ID = "id";
     public static final String ACTION = "action";
     public static final String PUBLIC_KEY_CREDENTIAL_CREATION_OPTIONS = "publicKeyCredentialCreationOptions";
+
+    public static class RegistrationConstants {
+
+        private RegistrationConstants() {
+
+        }
+
+        public static final String USER_IDENTITY = "userIdentity";
+        public static final String CREDENTIAL_NICKNAME = "credentialNickname";
+        public static final String ATTESTATION_METADATA = "attestationMetadata";
+        public static final String SIGNATURE_COUNT = "signatureCount";
+        public static final String DISPLAY_NAME = "displayName";
+        public static final String IS_USERNAMELESS_SUPPORTED = "isUsernamelessSupported";
+        public static final String REGISTRATION_TIME = "registrationTime";
+    }
 
     public static class ActionTypes {
 

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDOUtil.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDOUtil.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yubico.internal.util.JacksonCodecs;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -86,5 +87,11 @@ public class FIDOUtil {
         }
 
         return mdsSchedulerInitialDelay;
+    }
+
+    public static boolean isRegistrationFlow(FlowExecutionContext context) {
+
+        return org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION.getType()
+                .equals(context.getFlowType());
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/RegistrationFlowCompletionListenerTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/RegistrationFlowCompletionListenerTest.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.fido2.executor;
+
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockObjectFactory;
+import org.testng.Assert;
+import org.testng.IObjectFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authenticator.fido2.dao.FIDO2DeviceStoreDAO;
+import org.wso2.carbon.identity.application.authenticator.fido2.dto.FIDO2CredentialRegistration;
+import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorServerException;
+import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2ExecutorConstants;
+import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDOUtil;
+import org.wso2.carbon.identity.flow.execution.engine.Constants;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionStep;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Unit tests for RegistrationFlowCompletionListener.
+ */
+@PrepareForTest({FIDOUtil.class, FIDO2DeviceStoreDAO.class})
+public class RegistrationFlowCompletionListenerTest {
+
+    private static final String USERNAME = "testuser";
+    private static final String CONTEXT_IDENTIFIER = "test-flow-123";
+    private static final String CREDENTIAL_ID = "test-credential-id";
+    private static final String DISPLAY_NAME = "Test Device";
+    private static final long SIGNATURE_COUNT = 1L;
+    private static final String REGISTRATION_TIME_STRING = "2025-01-01T10:00:00Z";
+
+    private RegistrationFlowCompletionListener listener;
+
+    @Mock
+    private FlowExecutionStep flowExecutionStep;
+
+    @Mock
+    private FlowExecutionContext flowExecutionContext;
+
+    @Mock
+    private FlowUser flowUser;
+
+    @Mock
+    private FIDO2DeviceStoreDAO deviceStoreDAO;
+
+    @BeforeMethod
+    public void setUp() {
+
+        initMocks(this);
+        listener = new RegistrationFlowCompletionListener();
+
+        mockStatic(FIDOUtil.class);
+        mockStatic(FIDO2DeviceStoreDAO.class);
+
+        when(FIDO2DeviceStoreDAO.getInstance()).thenReturn(deviceStoreDAO);
+        when(flowExecutionContext.getFlowUser()).thenReturn(flowUser);
+        when(flowUser.getUsername()).thenReturn(USERNAME);
+        when(flowExecutionContext.getContextIdentifier()).thenReturn(CONTEXT_IDENTIFIER);
+    }
+
+    @Test
+    public void testGetExecutionOrderId() {
+
+        Assert.assertEquals(listener.getExecutionOrderId(), 5);
+    }
+
+    @Test
+    public void testGetDefaultOrderId() {
+
+        Assert.assertEquals(listener.getDefaultOrderId(), 5);
+    }
+
+    @Test
+    public void testIsEnabled() {
+
+        Assert.assertTrue(listener.isEnabled());
+    }
+
+    @Test
+    public void testDoPostExecuteWithRegistrationFlowAndCompleteStatus() throws Exception {
+
+        when(FIDOUtil.isRegistrationFlow(flowExecutionContext)).thenReturn(true);
+        when(flowExecutionStep.getFlowStatus()).thenReturn(Constants.STATUS_COMPLETE);
+        Map<String, Object> credentialRegistrationMap = createTestCredentialRegistrationMap();
+        when(flowExecutionContext.getProperty(FIDO2ExecutorConstants.CREDENTIAL_REGISTRATION))
+                .thenReturn(credentialRegistrationMap);
+        doNothing().when(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+        boolean result = listener.doPostExecute(flowExecutionStep, flowExecutionContext);
+        Assert.assertTrue(result);
+        verify(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+    }
+
+    @Test
+    public void testDoPostExecuteWithNonRegistrationFlow() throws Exception {
+
+        when(FIDOUtil.isRegistrationFlow(flowExecutionContext)).thenReturn(false);
+        when(flowExecutionStep.getFlowStatus()).thenReturn(Constants.STATUS_COMPLETE);
+        boolean result = listener.doPostExecute(flowExecutionStep, flowExecutionContext);
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void testDoPostExecuteWithIncompleteStatus() throws Exception {
+
+        when(FIDOUtil.isRegistrationFlow(flowExecutionContext)).thenReturn(true);
+        when(flowExecutionStep.getFlowStatus()).thenReturn(Constants.STATUS_INCOMPLETE);
+        boolean result = listener.doPostExecute(flowExecutionStep, flowExecutionContext);
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void testDoPostExecuteWithNullCredentialRegistration() throws Exception {
+
+        when(FIDOUtil.isRegistrationFlow(flowExecutionContext)).thenReturn(true);
+        when(flowExecutionStep.getFlowStatus()).thenReturn(Constants.STATUS_COMPLETE);
+        when(flowExecutionContext.getProperty(FIDO2ExecutorConstants.CREDENTIAL_REGISTRATION))
+                .thenReturn(null);
+        boolean result = listener.doPostExecute(flowExecutionStep, flowExecutionContext);
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void testDoPostExecuteWithDAOException() throws Exception {
+
+        when(FIDOUtil.isRegistrationFlow(flowExecutionContext)).thenReturn(true);
+        when(flowExecutionStep.getFlowStatus()).thenReturn(Constants.STATUS_COMPLETE);
+
+        Map<String, Object> credentialRegistrationMap = createTestCredentialRegistrationMap();
+        when(flowExecutionContext.getProperty(FIDO2ExecutorConstants.CREDENTIAL_REGISTRATION))
+                .thenReturn(credentialRegistrationMap);
+        doThrow(new FIDO2AuthenticatorServerException("DAO error", new Exception("Test exception")))
+                .when(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+        boolean result = listener.doPostExecute(flowExecutionStep, flowExecutionContext);
+        Assert.assertTrue(result);
+        verify(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+    }
+
+    @Test
+    public void testBuildFromMapWithCompleteData() throws Exception {
+
+        when(FIDOUtil.isRegistrationFlow(flowExecutionContext)).thenReturn(true);
+        when(flowExecutionStep.getFlowStatus()).thenReturn(Constants.STATUS_COMPLETE);
+
+        Map<String, Object> credentialRegistrationMap = createTestCredentialRegistrationMap();
+        when(flowExecutionContext.getProperty(FIDO2ExecutorConstants.CREDENTIAL_REGISTRATION))
+                .thenReturn(credentialRegistrationMap);
+        doNothing().when(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+        boolean result = listener.doPostExecute(flowExecutionStep, flowExecutionContext);
+        Assert.assertTrue(result);
+        verify(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+    }
+
+    @Test
+    public void testBuildFromMapWithMinimalData() throws Exception {
+
+        when(FIDOUtil.isRegistrationFlow(flowExecutionContext)).thenReturn(true);
+        when(flowExecutionStep.getFlowStatus()).thenReturn(Constants.STATUS_COMPLETE);
+
+        Map<String, Object> credentialRegistrationMap = createMinimalCredentialRegistrationMap();
+        when(flowExecutionContext.getProperty(FIDO2ExecutorConstants.CREDENTIAL_REGISTRATION))
+                .thenReturn(credentialRegistrationMap);
+        doNothing().when(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+        boolean result = listener.doPostExecute(flowExecutionStep, flowExecutionContext);
+        Assert.assertTrue(result);
+        verify(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+    }
+
+    @Test
+    public void testBuildFromMapWithNullOptionalFields() throws Exception {
+
+        when(FIDOUtil.isRegistrationFlow(flowExecutionContext)).thenReturn(true);
+        when(flowExecutionStep.getFlowStatus()).thenReturn(Constants.STATUS_COMPLETE);
+        Map<String, Object> credentialRegistrationMap = createCredentialRegistrationMapWithNulls();
+        when(flowExecutionContext.getProperty(FIDO2ExecutorConstants.CREDENTIAL_REGISTRATION))
+                .thenReturn(credentialRegistrationMap);
+        doNothing().when(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+        boolean result = listener.doPostExecute(flowExecutionStep, flowExecutionContext);
+        Assert.assertTrue(result);
+        verify(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+    }
+
+    @Test
+    public void testBuildFromMapWithoutRegistrationTime() throws Exception {
+
+        when(FIDOUtil.isRegistrationFlow(flowExecutionContext)).thenReturn(true);
+        when(flowExecutionStep.getFlowStatus()).thenReturn(Constants.STATUS_COMPLETE);
+        Map<String, Object> credentialRegistrationMap = createTestCredentialRegistrationMap();
+        credentialRegistrationMap.remove(FIDO2ExecutorConstants.RegistrationConstants.REGISTRATION_TIME);
+        when(flowExecutionContext.getProperty(FIDO2ExecutorConstants.CREDENTIAL_REGISTRATION))
+                .thenReturn(credentialRegistrationMap);
+        doNothing().when(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+        boolean result = listener.doPostExecute(flowExecutionStep, flowExecutionContext);
+        Assert.assertTrue(result);
+        verify(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+    }
+
+    @Test
+    public void testBuildFromMapWithZeroSignatureCount() throws Exception {
+
+        when(FIDOUtil.isRegistrationFlow(flowExecutionContext)).thenReturn(true);
+        when(flowExecutionStep.getFlowStatus()).thenReturn(Constants.STATUS_COMPLETE);
+        Map<String, Object> credentialRegistrationMap = createTestCredentialRegistrationMap();
+        credentialRegistrationMap.put(FIDO2ExecutorConstants.RegistrationConstants.SIGNATURE_COUNT, null);
+        when(flowExecutionContext.getProperty(FIDO2ExecutorConstants.CREDENTIAL_REGISTRATION))
+                .thenReturn(credentialRegistrationMap);
+        doNothing().when(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+        boolean result = listener.doPostExecute(flowExecutionStep, flowExecutionContext);
+        Assert.assertTrue(result);
+        verify(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+    }
+
+    @Test
+    public void testBuildFromMapWithUsernamelessSupported() throws Exception {
+
+        when(FIDOUtil.isRegistrationFlow(flowExecutionContext)).thenReturn(true);
+        when(flowExecutionStep.getFlowStatus()).thenReturn(Constants.STATUS_COMPLETE);
+        Map<String, Object> credentialRegistrationMap = createTestCredentialRegistrationMap();
+        credentialRegistrationMap.put(FIDO2ExecutorConstants.RegistrationConstants.IS_USERNAMELESS_SUPPORTED, true);
+        when(flowExecutionContext.getProperty(FIDO2ExecutorConstants.CREDENTIAL_REGISTRATION))
+                .thenReturn(credentialRegistrationMap);
+        doNothing().when(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+        boolean result = listener.doPostExecute(flowExecutionStep, flowExecutionContext);
+        Assert.assertTrue(result);
+        verify(deviceStoreDAO).addFIDO2RegistrationByUsername(eq(USERNAME), any(FIDO2CredentialRegistration.class));
+    }
+
+    /**
+     * Helper method to create a complete credential registration map for testing.
+     */
+    private Map<String, Object> createTestCredentialRegistrationMap() {
+
+        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put("credentialId", CREDENTIAL_ID);
+        credentialMap.put("userHandle", "test-user-handle");
+        credentialMap.put("publicKeyCose", "test-public-key");
+        credentialMap.put("signatureCount", SIGNATURE_COUNT);
+        map.put(FIDO2ExecutorConstants.CREDENTIAL, credentialMap);
+        Map<String, Object> userIdentityMap = new HashMap<>();
+        userIdentityMap.put("name", USERNAME);
+        userIdentityMap.put("displayName", "Test User");
+        userIdentityMap.put("id", "test-user-id");
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.USER_IDENTITY, userIdentityMap);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.CREDENTIAL_NICKNAME, "Test Nickname");
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.ATTESTATION_METADATA, null);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.SIGNATURE_COUNT, SIGNATURE_COUNT);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.DISPLAY_NAME, DISPLAY_NAME);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.IS_USERNAMELESS_SUPPORTED, false);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.REGISTRATION_TIME, REGISTRATION_TIME_STRING);
+        return map;
+    }
+
+    /**
+     * Helper method to create a minimal credential registration map for testing.
+     */
+    private Map<String, Object> createMinimalCredentialRegistrationMap() {
+
+        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put("credentialId", CREDENTIAL_ID);
+        credentialMap.put("userHandle", "test-user-handle");
+        credentialMap.put("publicKeyCose", "test-public-key");
+        credentialMap.put("signatureCount", 0L);
+        map.put(FIDO2ExecutorConstants.CREDENTIAL, credentialMap);
+
+        Map<String, Object> userIdentityMap = new HashMap<>();
+        userIdentityMap.put("name", USERNAME);
+        userIdentityMap.put("displayName", USERNAME);
+        userIdentityMap.put("id", "test-user-id");
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.USER_IDENTITY, userIdentityMap);
+
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.SIGNATURE_COUNT, 0L);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.DISPLAY_NAME, USERNAME);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.IS_USERNAMELESS_SUPPORTED, false);
+
+        return map;
+    }
+
+    /**
+     * Helper method to create a credential registration map with null optional fields.
+     */
+    private Map<String, Object> createCredentialRegistrationMapWithNulls() {
+
+        Map<String, Object> map = new HashMap<>();
+
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put("credentialId", CREDENTIAL_ID);
+        credentialMap.put("userHandle", "test-user-handle");
+        credentialMap.put("publicKeyCose", "test-public-key");
+        credentialMap.put("signatureCount", SIGNATURE_COUNT);
+        map.put(FIDO2ExecutorConstants.CREDENTIAL, credentialMap);
+
+        Map<String, Object> userIdentityMap = new HashMap<>();
+        userIdentityMap.put("name", USERNAME);
+        userIdentityMap.put("displayName", "Test User");
+        userIdentityMap.put("id", "test-user-id");
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.USER_IDENTITY, userIdentityMap);
+
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.CREDENTIAL_NICKNAME, null);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.ATTESTATION_METADATA, null);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.SIGNATURE_COUNT, SIGNATURE_COUNT);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.DISPLAY_NAME, null);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.IS_USERNAMELESS_SUPPORTED, false);
+        map.put(FIDO2ExecutorConstants.RegistrationConstants.REGISTRATION_TIME, null);
+
+        return map;
+    }
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+
+        return new PowerMockObjectFactory();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,11 @@
                 <artifactId>org.wso2.carbon.identity.flow.execution.engine</artifactId>
                 <version>${identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.flow.mgt</artifactId>
+                <version>${identity.framework.version}</version>
+            </dependency>
 
             <!--Test Dependencies-->
             <dependency>
@@ -418,7 +423,7 @@
 
     <properties>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <identity.framework.version>7.8.215</identity.framework.version>
+        <identity.framework.version>7.8.356</identity.framework.version>
         <carbon.identity.governance.version>1.8.40</carbon.identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.3.0, 3.0.0)</identity.governance.imp.pkg.version.range>
         <carbon.identity.package.import.version.range>[5.0.0, 8.0.0)</carbon.identity.package.import.version.range>


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24918

This pull request introduces enhancements to the FIDO2 authentication module, focusing on improving the registration flow and handling of credentials. Key changes include the addition of a new method for creating FIDO2 credentials without database storage, integration of a flow execution listener for registration completion, and updates to dependency management for better modularity.

### Enhancements to FIDO2 Registration Flow:
- **New Method for Credential Creation**: Added `createFIDO2Credential` method in `WebAuthnService` to generate FIDO2 credential registrations without storing them in the database, enabling flexibility during registration flows.
- **Registration Flow Completion Listener**: Introduced `RegistrationFlowCompletionListener` to handle post-registration actions, such as storing credentials in the database upon flow completion. This ensures proper handling of user credentials.
- **Executor Updates**: Modified `FIDO2Executor` to utilize the new `createFIDO2Credential` method for registration flows and added logic to convert credential registrations into a map for context properties. [[1]](diffhunk://#diff-a70fbc55431b14d91d0ae1dda0726f3ef5934270fa49830a5d99d7862536acfcR109-R116) [[2]](diffhunk://#diff-a70fbc55431b14d91d0ae1dda0726f3ef5934270fa49830a5d99d7862536acfcR224-R230)

### Dependency and Component Updates:
- **Dependency Addition**: Added `org.wso2.carbon.identity.flow.mgt` as a dependency in `pom.xml` to support flow management functionalities. [[1]](diffhunk://#diff-5bccacf85fe06802ebf36913d4daf802cd88fc3bb754245ee0b70b45f669289dR98-R101) [[2]](diffhunk://#diff-5bccacf85fe06802ebf36913d4daf802cd88fc3bb754245ee0b70b45f669289dR187-R188)
- **Service Component Registration**: Registered `RegistrationFlowCompletionListener` as a `FlowExecutionListener` in `FIDO2AuthenticatorServiceComponent` for seamless integration with the flow execution engine. [[1]](diffhunk://#diff-5d13ed2102d16937cc9d980c059f6e269939e90abd44296adbd07efd02d99cf9R32-R38) [[2]](diffhunk://#diff-5d13ed2102d16937cc9d980c059f6e269939e90abd44296adbd07efd02d99cf9R68)

### Documentation and Code Comments:
- **Improved Documentation**: Added detailed JavaDoc comments to `FIDO2Executor` and `RegistrationFlowCompletionListener` classes, improving code readability and maintainability. [[1]](diffhunk://#diff-a70fbc55431b14d91d0ae1dda0726f3ef5934270fa49830a5d99d7862536acfcR53-R55) [[2]](diffhunk://#diff-70cdc8cfe960e72d6baf3490b3d786f4a13f3f9508f498ba5add36612b571670R1-R130)

