### PR TITLE
Extends authentication executor

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/FIDO2Executor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/FIDO2Executor.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.application.authenticator.fido2.util.Either;
 import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2ExecutorConstants;
 import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDOUtil;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
+import org.wso2.carbon.identity.flow.execution.engine.graph.AuthenticationExecutor;
 import org.wso2.carbon.identity.flow.execution.engine.graph.Executor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
@@ -53,7 +54,7 @@ import static org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO
 /**
  * FIDO2 Executor for handling FIDO2 registration and authentication flows.
  */
-public class FIDO2Executor implements Executor {
+public class FIDO2Executor extends AuthenticationExecutor {
 
     private static final WebAuthnService webAuthnService = new WebAuthnService();
 
@@ -61,6 +62,12 @@ public class FIDO2Executor implements Executor {
     public String getName() {
 
         return "FIDO2Executor";
+    }
+
+    @Override
+    public String getAMRValue() {
+
+        return FIDO2ExecutorConstants.DEFAULT_AMR_VALUE;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2ExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2ExecutorConstants.java
@@ -36,6 +36,7 @@ public class FIDO2ExecutorConstants {
     public static final String ID = "id";
     public static final String ACTION = "action";
     public static final String PUBLIC_KEY_CREDENTIAL_CREATION_OPTIONS = "publicKeyCredentialCreationOptions";
+    public static final String DEFAULT_AMR_VALUE = "FIDOAuthenticator";
 
     public static class RegistrationConstants {
 


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24768

This pull request updates the `FIDO2Executor` to better integrate with the authentication flow engine by extending the `AuthenticationExecutor` base class and adds support for returning an Authentication Method Reference (AMR) value. The changes improve code consistency and allow the FIDO2 authenticator to correctly report its AMR value, which is important for downstream authentication handling.

Integration and extensibility:

* Changed `FIDO2Executor` to extend `AuthenticationExecutor` instead of implementing `Executor`, enabling better integration with the authentication flow engine and access to additional framework features.
* Imported the `AuthenticationExecutor` class to support the new base class.

AMR value support:

* Added a `getAMRValue()` method to `FIDO2Executor` to return the default AMR value, improving compatibility with authentication flows that require AMR reporting.
* Defined `DEFAULT_AMR_VALUE` in `FIDO2ExecutorConstants` for consistent use of the AMR value across the codebase.