### PR TITLE
[master] Return empty authinitiation data when no passkeys enrolled in app-native flow

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -100,6 +100,7 @@ import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOA
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.FIDO_KEY_DISPLAY_NAME;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.FIDO_KEY_ID;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.IS_PASSKEY_CREATION_CONSENT_RECEIVED;
+import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.IS_API_BASED_AND_NO_PASSKEY_ENROLLED;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.LogConstants.ActionIDs.PROCESS_AUTHENTICATION_RESPONSE;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.LogConstants.ActionIDs.VALIDATE_FIDO_REQUEST;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.LogConstants.FIDO_AUTH_SERVICE;
@@ -182,6 +183,15 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             }
             authenticatedUser.setUserName(mappedLocalUsername);
             boolean enrolledPasskeysExist = hasUserSetPasskeys(authenticatedUser);
+
+            // If the request is API based and no passkeys are enrolled, then redirect the user to error page.
+            if (isAPIBasedAuthRequest(request) && !enrolledPasskeysExist) {
+                // App-native doesn't support progressive passkey enrollment.
+                // TODO: This need to be updated once the app-native supports progressive passkey enrollment.
+                context.setProperty(IS_API_BASED_AND_NO_PASSKEY_ENROLLED, true);
+                redirectToNoPasskeyEnrolledErrorPage(response, context);
+                return AuthenticatorFlowStatus.INCOMPLETE;
+            }
             if (enrolledPasskeysExist) {
                 // If the user have already enrolled passkeys and if the user initiated a passkey enrollment request,
                 // then inform the user that passkeys already exist and disregard the enrollment request.
@@ -732,6 +742,11 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             authenticatorData.setMessage((AuthenticatorMessage) propertyValue);
         }
 
+        if (Boolean.TRUE.equals(context.getProperty(IS_API_BASED_AND_NO_PASSKEY_ENROLLED))) {
+            // If the request is API based and no passkeys are enrolled, only authenticator data is added.
+            return Optional.of(authenticatorData);
+        }
+
         List<String> requiredParameterList = new ArrayList<>();
         requiredParameterList.add(TOKEN_RESPONSE);
         authenticatorData.setRequiredParams(requiredParameterList);
@@ -1272,6 +1287,22 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                                 IdentityCoreConstants.UTF_8);
 
         return buildAbsoluteURL(provisionedUserNotFoundRedirectUrl);
+    }
+
+    private void redirectToNoPasskeyEnrolledErrorPage(HttpServletResponse response, AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        try {
+            String queryParams = FrameworkUtils.getQueryStringWithFrameworkContextId(context.getQueryParams(),
+                    context.getCallerSessionKey(), context.getContextIdentifier());
+            queryParams += FIDOAuthenticatorConstants.NO_PASSKEY_ENROLLED_ERROR_QUERY_PARAMS;
+            String errorPage = FIDOUtil.getErrorPageUrl();
+            String url = FrameworkUtils.appendQueryParamsStringToUrl(errorPage, queryParams);
+            response.sendRedirect(url);
+        } catch (IOException e) {
+            throw new AuthenticationFailedException(FIDOAuthenticatorConstants.ERROR_REDIRECTING_TO_ERROR_PAGE_MESSAGE,
+                    e);
+        }
     }
 
     private IdentityProvider getIdentityProvider(String idpName, String tenantDomain) throws

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/util/FIDOAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/util/FIDOAuthenticatorConstants.java
@@ -38,6 +38,8 @@ public class FIDOAuthenticatorConstants {
             "Error occurred while checking account lock status for user: %s";
     public static final String ACCOUNT_LOCKED_ERROR_QUERY_PARAMS =
             "&authFailure=true&authFailureMsg=error.user.account.locked";
+    public static final String NO_PASSKEY_ENROLLED_ERROR_QUERY_PARAMS =
+            "&authFailure=true&authFailureMsg=no.enrolled.passkey.found";
     public static final String ERROR_REDIRECTING_TO_ERROR_PAGE_MESSAGE =
             "Error occurred while redirecting to error page";
 
@@ -61,6 +63,7 @@ public class FIDOAuthenticatorConstants {
 
     public static final String WEBAUTHN_ENABLED = "FIDO.WebAuthn.Enable";
     public static final String IS_PASSKEY_CREATION_CONSENT_RECEIVED = "isPasskeyCreationConsentReceived";
+    public static final String IS_API_BASED_AND_NO_PASSKEY_ENROLLED = "isApiBasedAndNoPasskeyEnrolled";
     public static final String TOKEN_RESPONSE = "tokenResponse";
     public static final String ERROR_CODE = "errorCode";
     public static final String CHALLENGE_RESPONSE = "challengeResponse";

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorTest.java
@@ -42,6 +42,8 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.A
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authenticator.fido.util.FIDOUtil;
 import org.wso2.carbon.identity.application.authenticator.fido.u2f.U2FService;
 import org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.fido2.core.WebAuthnService;
@@ -74,6 +76,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.AUTHENTICATOR_FIDO;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME;
+import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.IS_API_BASED_AND_NO_PASSKEY_ENROLLED;
 
 public class FIDOAuthenticatorTest {
 
@@ -587,6 +590,26 @@ public class FIDOAuthenticatorTest {
         Assert.assertTrue(additionalData.containsKey(FIDOAuthenticatorConstants.CHALLENGE_DATA));
     }
 
+    @Test(description = "Test case for getAuthInitiationData() when the request is API based and no passkeys are"
+            + " enrolled - should return authenticator data without required params or additional data.")
+    public void testGetAuthInitiationDataWhenAPIBasedAndNoPasskeyEnrolled() {
+
+        when(authenticationContext.getExternalIdP()).thenReturn(externalIdPConfig);
+        when(externalIdPConfig.getIdPName()).thenReturn("LOCAL");
+        authenticationContext.setProperty(IS_API_BASED_AND_NO_PASSKEY_ENROLLED, true);
+
+        Optional<AuthenticatorData> authenticatorData = fidoAuthenticator.getAuthInitiationData(authenticationContext);
+
+        Assert.assertTrue(authenticatorData.isPresent());
+        AuthenticatorData authenticatorDataObj = authenticatorData.get();
+        Assert.assertEquals(authenticatorDataObj.getDisplayName(), AUTHENTICATOR_FRIENDLY_NAME);
+        Assert.assertEquals(authenticatorDataObj.getI18nKey(), AUTHENTICATOR_FIDO);
+        Assert.assertEquals(authenticatorDataObj.getPromptType(),
+                FrameworkConstants.AuthenticatorPromptType.INTERNAL_PROMPT);
+        Assert.assertTrue(authenticatorDataObj.getRequiredParams().isEmpty());
+        Assert.assertNull(authenticatorDataObj.getAdditionalData());
+    }
+
     @Test
     public void testIsAPIBasedAuthenticationSupported() {
 
@@ -642,6 +665,44 @@ public class FIDOAuthenticatorTest {
         } catch (AuthenticationFailedException e) {
             Assert.assertTrue(e.getMessage()
                     .contains(FIDOAuthenticatorConstants.AUTHENTICATION_FAILED_ACCOUNT_LOCKED_ERROR_MESSAGE));
+        }
+    }
+
+    @Test(description = "Test case for API based auth request when no passkeys are enrolled - should redirect to error"
+            + " page and return INCOMPLETE.", priority = 16)
+    public void testProcessAPIBasedAuthRequestWithNoPasskeyEnrolled() throws Exception {
+
+        AuthenticationContext context = new AuthenticationContext();
+        AuthenticatedUser authenticatedUser = AuthenticatedUser
+                .createLocalAuthenticatedUserFromSubjectIdentifier(USERNAME);
+        authenticatedUser.setFederatedUser(false);
+        authenticatedUser.setUserName(USERNAME);
+        authenticatedUser.setUserStoreDomain(USER_STORE_DOMAIN);
+        authenticatedUser.setTenantDomain(SUPER_TENANT_DOMAIN);
+
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepConfig);
+        SequenceConfig sequenceConfig = new SequenceConfig();
+        sequenceConfig.setStepMap(stepMap);
+        context.setSequenceConfig(sequenceConfig);
+        context.setContextIdentifier(UUID.randomUUID().toString());
+
+        identityUtilMock.when(IdentityUtil::getPrimaryDomainName).thenReturn(USER_STORE_DOMAIN);
+        when(httpServletRequest.getAttribute(FrameworkConstants.IS_API_BASED_AUTH_FLOW)).thenReturn(Boolean.TRUE);
+
+        try (MockedStatic<FIDOUtil> fidoUtilMock = Mockito.mockStatic(FIDOUtil.class);
+             MockedStatic<FrameworkUtils> frameworkUtilsMock = Mockito.mockStatic(FrameworkUtils.class);
+             MockedConstruction<WebAuthnService> ignored = Mockito.mockConstruction(WebAuthnService.class,
+                     (mock, ctx) -> when(mock.isFidoKeyRegistered(any(AuthenticatedUser.class))).thenReturn(false))) {
+
+            AuthenticatorFlowStatus status = fidoAuthenticator.process(
+                    httpServletRequest, httpServletResponse, context);
+
+            Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
+            Assert.assertEquals(context.getProperty(IS_API_BASED_AND_NO_PASSKEY_ENROLLED), true);
         }
     }
 


### PR DESCRIPTION
### Purpose

NPE exception occurs in the app-native flow when FIDO authenticator is configured and an authenticated user is present. In this scenario, the flow is expected to redirect the user to the passkey enrolment consent page(when progressive enrolment is enabled) or passkey existence status page(when progressive enrolment is disabled) . However, app-native flows do not honor the redirect-URL-based response generation and instead proceed to add additional data to the authInitiation dataset. Since the required additional data (e.g., the FIDO challenge [1]) is not generated—as the flow is supposed to redirect to the expected page—a NullPointerException (NPE) is thrown.


This change introduces the context property `IS_API_BASED_AND_NO_PASSKEY_ENROLLED` for API-based requests with no enrolled passkey (regardless of progressive enrolment state). When present, the flow returns only authenticator data in the authInitiation dataset and conditionally builds a redirect URL to the FIDO error page with the following parameters:

```
&authFailure=true&authFailureMsg=no.enrolled.passkey.found
```

Previously the NPE is handled as a bad request with the following error:
```
 {
    "code": "ABA-60002",
    "message": "Authentication failure.",
    "description": "Authentication flow has concluded with a failure.",
    "traceId": "189aed2c-e16e-4764-b77e-43d5acbdeb2f"
}
```

This change will set the flow status to `FAIL_INCOMPLETE` and a descriptive error message as follows:

```
{
    "flowId": "e4abdc3c-2618-4153-bb13-a12e5fb7c387",
    "flowStatus": "FAIL_INCOMPLETE",
    "flowType": "AUTHENTICATION",
    "nextStep": {
        "stepType": "AUTHENTICATOR_PROMPT",
        "authenticators": [
            {
                "authenticatorId": "RklET0F1dGhlbnRpY2F0b3I6TE9DQUw",
                "authenticator": "Passkey",
                "idp": "LOCAL",
                "metadata": {
                    "i18nKey": "authenticator.Fido"
                }
            }
        ],
        "messages": [
            {
                "type": "ERROR",
                "messageId": "ABA-60003",
                "message": "no.enrolled.passkey.found",
                "i18nKey": "message.ABA-60003"
            }
        ]
    },
    "links": [
        {
            "name": "authentication",
            "href": "https://localhost:9443/oauth2/authn",
            "method": "POST"
        }
    ]
}
```

[1] https://github.com/wso2-extensions/identity-local-auth-fido/blob/fcd4fd628c50f4aca1a4ac0f30f46095649d6bf9/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java#L741


### Related issues
- https://github.com/wso2/product-is/issues/26617