### PR TITLE
Add support for explicit rpId resolution in FIDO2 authentication flows

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2015-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -77,8 +77,10 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -527,7 +529,6 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             tokenResponse = base64URLDecode(request.getParameter(TOKEN_RESPONSE));
         }
         if (tokenResponse != null && !tokenResponse.contains(ERROR_CODE)) {
-            String appID = FIDOUtil.getOrigin(request);
             if (isWebAuthnEnabled()) {
                 if (user == null) {
                     user = processFido2UsernamelessAuthenticationResponse(tokenResponse);
@@ -535,6 +536,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                     processFido2AuthenticationResponse(user, tokenResponse);
                 }
             } else {
+                String appID = FIDOUtil.getOrigin(request);
                 processFidoAuthenticationResponse(user, appID, tokenResponse);
             }
             user.setAuthenticatedSubjectIdentifier(user.getUsernameAsSubjectIdentifier(true, true));
@@ -687,8 +689,9 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         // Origin as appID eg: https://example.com:8080
         String appID = resolveAppId(request);
 
+        boolean isAPIBased = isAPIBasedAuthRequest(request);
         try {
-            String redirectUrl = getRedirectUrl(response, user, appID, getLoginPage(), context);
+            String redirectUrl = getRedirectUrl(response, user, appID, getLoginPage(), context, isAPIBased);
             response.sendRedirect(redirectUrl);
             if (LoggerUtils.isDiagnosticLogsEnabled()) {
                 DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
@@ -829,7 +832,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
     }
 
     private String initiateFido2AuthenticationRequest(AuthenticatedUser user, String appID, AuthenticationContext
-            context) throws AuthenticationFailedException {
+            context, boolean isAPIBased) throws AuthenticationFailedException {
 
         WebAuthnService webAuthnService = new WebAuthnService();
 
@@ -849,12 +852,49 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             }
         }
 
+        // In API-based flows, resolve the rpId and effective appId from the AppID configured via adaptive script
+        // authenticator params. Browser-redirect flows are unaffected and rely solely on appID from resolveAppId().
+        String resolvedRpId = null;
+        String resolvedAppId = null;
+        String rpName = null;
+        if (isAPIBased) {
+            String spName = context.getServiceProviderName();
+            if (StringUtils.isNotBlank(spName)) {
+                rpName = spName;
+            }
+            // AppID set via adaptive script authenticator params.
+            Map<String, String> params = getRuntimeParams(context);
+            String scriptAppId = params != null ? params.get(FIDOAuthenticatorConstants.SCRIPT_APP_ID) : null;
+            if (StringUtils.isNotBlank(scriptAppId)) {
+                try {
+                    resolvedRpId = new URL(scriptAppId).getHost();
+                    resolvedAppId = scriptAppId;
+                } catch (MalformedURLException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Malformed AppID value '" + scriptAppId +
+                                "' set via adaptive script parameters.", e);
+                    }
+                    throw new AuthenticationFailedException("Malformed AppID value set via " +
+                            "adaptive script parameters: " + scriptAppId, e);
+                }
+            }
+        }
+
+        String effectiveAppId = resolvedAppId != null ? resolvedAppId : appID;
+
         //Initiate the usernameless authentication process when either the user is unidentified or the identified user
         // lacks an enrolled passkey.
         if (user == null || !hasUserSetPasskeys(user)) {
+            if (resolvedRpId != null) {
+                return webAuthnService.startUsernamelessAuthenticationWithRpId(resolvedRpId, rpName, effectiveAppId);
+            }
             return webAuthnService.startUsernamelessAuthentication(appID);
         }
 
+        if (resolvedRpId != null) {
+            return webAuthnService.startAuthenticationWithRpId(resolvedRpId, rpName, user.getUserName(),
+                    user.getTenantDomain(), user.getUserStoreDomain(), effectiveAppId);
+        }
         return webAuthnService.startAuthentication(user.getUserName(),
                 user.getTenantDomain(), user.getUserStoreDomain(), appID);
     }
@@ -933,12 +973,12 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
     }
 
     private String getRedirectUrl(HttpServletResponse response, AuthenticatedUser user, String appID, String loginPage,
-                                  AuthenticationContext context)
+                                  AuthenticationContext context, boolean isAPIBased)
             throws AuthenticationFailedException, UnsupportedEncodingException, URLBuilderException,
             URISyntaxException {
 
         if (isWebAuthnEnabled()) {
-            String data = initiateFido2AuthenticationRequest(user, appID, context);
+            String data = initiateFido2AuthenticationRequest(user, appID, context, isAPIBased);
             context.setProperty(FIDOAuthenticatorConstants.AUTHENTICATOR_NAME +
                     FIDOAuthenticatorConstants.CHALLENGE_DATA_SUFFIX, data);
             if (StringUtils.isNotBlank(data)) {

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/util/FIDOAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/util/FIDOAuthenticatorConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2015-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -53,6 +53,7 @@ public class FIDOAuthenticatorConstants {
     public static final String FIDO2_PASSKEY_STATUS = "Fido2PasskeyStatus";
     public static final String FIDO2_IDENTIFIER_FIRST = "Fido2IdentifierFirst";
     public static final String APP_ID = "AppID";
+    public static final String SCRIPT_APP_ID = "appId";
 
     public static final String URI_LOGIN = "login.do";
     public static final String URI_FIDO_LOGIN = "fido-auth.jsp";

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2022-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -73,6 +73,9 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.AUTHENTICATOR_FIDO;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME;
@@ -125,10 +128,10 @@ public class FIDOAuthenticatorTest {
         fidoAuthenticator = FIDOAuthenticator.getInstance();
         MockitoAnnotations.openMocks(this);
 
-        identityUtilMock = Mockito.mockStatic(IdentityUtil.class);
-        loggerUtilsMock = Mockito.mockStatic(LoggerUtils.class);
-        fidoAuthenticatorServiceDataHolderMock = Mockito.mockStatic(FIDOAuthenticatorServiceDataHolder.class);
-        identityTenantUtilStatic = Mockito.mockStatic(IdentityTenantUtil.class);
+        identityUtilMock = mockStatic(IdentityUtil.class);
+        loggerUtilsMock = mockStatic(LoggerUtils.class);
+        fidoAuthenticatorServiceDataHolderMock = mockStatic(FIDOAuthenticatorServiceDataHolder.class);
+        identityTenantUtilStatic = mockStatic(IdentityTenantUtil.class);
 
         loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
         fidoAuthenticatorServiceDataHolderMock.when(FIDOAuthenticatorServiceDataHolder::getInstance)
@@ -212,7 +215,7 @@ public class FIDOAuthenticatorTest {
             }
         };
 
-        serviceURLBuilderMock = Mockito.mockStatic(ServiceURLBuilder.class);
+        serviceURLBuilderMock = mockStatic(ServiceURLBuilder.class);
         serviceURLBuilderMock.when(ServiceURLBuilder::create).thenReturn(builder);
     }
 
@@ -376,9 +379,9 @@ public class FIDOAuthenticatorTest {
         identityUtilMock.when(() -> IdentityUtil.getProperty(FIDOAuthenticatorConstants.WEBAUTHN_ENABLED))
                 .thenReturn(String.valueOf(false));
 
-        u2FServiceMock = Mockito.mockStatic(U2FService.class);
+        u2FServiceMock = mockStatic(U2FService.class);
         u2FServiceMock.when(U2FService::getInstance).thenReturn(u2FService);
-        authenticateResponseMock = Mockito.mockStatic(AuthenticateResponse.class);
+        authenticateResponseMock = mockStatic(AuthenticateResponse.class);
         authenticateResponseMock.when(() -> AuthenticateResponse.fromJson(anyString())).thenReturn(authenticateResponse);
 
         fidoAuthenticator.processAuthenticationResponse(httpServletRequest, httpServletResponse, context);
@@ -453,12 +456,12 @@ public class FIDOAuthenticatorTest {
         parameterMap.put(FIDOAuthenticatorConstants.FIDO2_AUTH, "fido2-auth");
         authenticatorConfig.setParameterMap(parameterMap);
 
-        fileBasedConfigurationBuilderMock = Mockito.mockStatic(FileBasedConfigurationBuilder.class);
+        fileBasedConfigurationBuilderMock = mockStatic(FileBasedConfigurationBuilder.class);
         fileBasedConfigurationBuilderMock.when(FileBasedConfigurationBuilder::getInstance)
                 .thenReturn(fileBasedConfigurationBuilder);
         when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(authenticatorConfig);
 
-        urlEncoderMock = Mockito.mockStatic(URLEncoder.class);
+        urlEncoderMock = mockStatic(URLEncoder.class);
         urlEncoderMock.when(() -> URLEncoder.encode(anyString(), anyString())).thenReturn("encodedUrl");
         mockServiceURLBuilder();
 
@@ -526,9 +529,9 @@ public class FIDOAuthenticatorTest {
         identityUtilMock.when(() -> IdentityUtil.getProperty(FIDOAuthenticatorConstants.WEBAUTHN_ENABLED))
                 .thenReturn(String.valueOf(false));
 
-        u2FServiceMock = Mockito.mockStatic(U2FService.class);
+        u2FServiceMock = mockStatic(U2FService.class);
         u2FServiceMock.when(U2FService::getInstance).thenReturn(u2FService);
-        authenticateResponseMock = Mockito.mockStatic(AuthenticateResponse.class);
+        authenticateResponseMock = mockStatic(AuthenticateResponse.class);
 
         if (isU2FNullResponse) {
             when(u2FService.startAuthentication(any())).thenReturn(null);
@@ -541,12 +544,12 @@ public class FIDOAuthenticatorTest {
         parameterMap.put(FIDOAuthenticatorConstants.FIDO_AUTH, "fido-auth");
         authenticatorConfig.setParameterMap(parameterMap);
 
-        fileBasedConfigurationBuilderMock = Mockito.mockStatic(FileBasedConfigurationBuilder.class);
+        fileBasedConfigurationBuilderMock = mockStatic(FileBasedConfigurationBuilder.class);
         fileBasedConfigurationBuilderMock.when(FileBasedConfigurationBuilder::getInstance)
                 .thenReturn(fileBasedConfigurationBuilder);
         when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(authenticatorConfig);
 
-        urlEncoderMock = Mockito.mockStatic(URLEncoder.class);
+        urlEncoderMock = mockStatic(URLEncoder.class);
         urlEncoderMock.when(() -> URLEncoder.encode(anyString(), anyString())).thenReturn("encodedUrl");
         mockServiceURLBuilder();
 
@@ -693,8 +696,8 @@ public class FIDOAuthenticatorTest {
         identityUtilMock.when(IdentityUtil::getPrimaryDomainName).thenReturn(USER_STORE_DOMAIN);
         when(httpServletRequest.getAttribute(FrameworkConstants.IS_API_BASED_AUTH_FLOW)).thenReturn(Boolean.TRUE);
 
-        try (MockedStatic<FIDOUtil> fidoUtilMock = Mockito.mockStatic(FIDOUtil.class);
-             MockedStatic<FrameworkUtils> frameworkUtilsMock = Mockito.mockStatic(FrameworkUtils.class);
+        try (MockedStatic<FIDOUtil> fidoUtilMock = mockStatic(FIDOUtil.class);
+             MockedStatic<FrameworkUtils> frameworkUtilsMock = mockStatic(FrameworkUtils.class);
              MockedConstruction<WebAuthnService> ignored = Mockito.mockConstruction(WebAuthnService.class,
                      (mock, ctx) -> when(mock.isFidoKeyRegistered(any(AuthenticatedUser.class))).thenReturn(false))) {
 
@@ -753,6 +756,190 @@ public class FIDOAuthenticatorTest {
             Assert.fail("Expected AuthenticationFailedException was not thrown");
         } catch (AuthenticationFailedException e) {
             Assert.assertTrue(e.getMessage().contains("Error occurred while checking account lock status for user"));
+        }
+    }
+
+    @Test(description = "Test case for initiateAuthenticationRequest() when API-based with valid rpId from " +
+            "adaptive script param for an identified user with passkeys", priority = 16)
+    public void testInitiateAuthenticationRequestApiBasedWithRpId() throws Exception {
+
+        AuthenticationContext context = new AuthenticationContext();
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        authenticatorConfig.setApplicationAuthenticator(fidoAuthenticator);
+        List<AuthenticatorConfig> authenticatorList = new ArrayList<>();
+        authenticatorList.add(authenticatorConfig);
+
+        AuthenticatedUser authenticatedUser = AuthenticatedUser
+                .createLocalAuthenticatedUserFromSubjectIdentifier(USERNAME);
+        authenticatedUser.setFederatedUser(false);
+        authenticatedUser.setUserName(USERNAME);
+        authenticatedUser.setTenantDomain(SUPER_TENANT_DOMAIN);
+        authenticatedUser.setUserStoreDomain(USER_STORE_DOMAIN);
+
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setAuthenticatorList(authenticatorList);
+        stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepConfig);
+        SequenceConfig sequenceConfig = new SequenceConfig();
+        sequenceConfig.setStepMap(stepMap);
+        context.setSequenceConfig(sequenceConfig);
+        context.setSubject(authenticatedUser);
+        context.setServiceProviderName("TestSP");
+        context.setContextIdentifier(UUID.randomUUID().toString());
+
+        when(IdentityUtil.getPrimaryDomainName()).thenReturn(USER_STORE_DOMAIN);
+        when(IdentityUtil.getProperty(FIDOAuthenticatorConstants.WEBAUTHN_ENABLED)).thenReturn(String.valueOf(true));
+        when(httpServletRequest.getAttribute(FrameworkConstants.IS_API_BASED_AUTH_FLOW)).thenReturn(Boolean.TRUE);
+
+        // Inject scriptAppId into context runtime params (read by AbstractApplicationAuthenticator.getRuntimeParams).
+        Map<String, String> scriptParams = new HashMap<>();
+        scriptParams.put(FIDOAuthenticatorConstants.SCRIPT_APP_ID, "https://abcd.example.com:9443");
+        Map<String, Map<String, String>> contextParamMap = new HashMap<>();
+        contextParamMap.put(FIDOAuthenticatorConstants.AUTHENTICATOR_NAME, scriptParams);
+        context.addAuthenticatorParams(contextParamMap);
+
+        Map<String, String> parameterMap = new HashMap<>();
+        parameterMap.put(FIDOAuthenticatorConstants.APP_ID, "https://localhost:9443");
+        parameterMap.put(FIDOAuthenticatorConstants.FIDO2_AUTH, "fido2-auth");
+        authenticatorConfig.setParameterMap(parameterMap);
+
+        fileBasedConfigurationBuilderMock = mockStatic(FileBasedConfigurationBuilder.class);
+        fileBasedConfigurationBuilderMock.when(FileBasedConfigurationBuilder::getInstance)
+                .thenReturn(fileBasedConfigurationBuilder);
+        when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(authenticatorConfig);
+
+        urlEncoderMock = mockStatic(URLEncoder.class);
+        urlEncoderMock.when(() -> URLEncoder.encode(anyString(), anyString())).thenReturn("encodedUrl");
+        mockServiceURLBuilder();
+
+        try (MockedConstruction<WebAuthnService> webAuthnServiceMockedConstruction = Mockito.mockConstruction(
+                WebAuthnService.class, (mock, context1) -> {
+                    when(mock.isFidoKeyRegistered(any(AuthenticatedUser.class))).thenReturn(true);
+                    when(mock.startAuthenticationWithRpId(anyString(), anyString(), anyString(),
+                            anyString(), anyString(), anyString())).thenReturn("rpIdAssertionRequest");
+                })) {
+            fidoAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, context);
+
+            WebAuthnService constructedMock = webAuthnServiceMockedConstruction.constructed().get(0);
+            verify(constructedMock).startAuthenticationWithRpId(eq("abcd.example.com"), eq("TestSP"),
+                    eq(USERNAME), anyString(), anyString(), anyString());
+            verify(constructedMock, never()).startAuthentication(anyString(), anyString(), anyString(), anyString());
+        }
+    }
+
+    @Test(description = "Test case for initiateAuthenticationRequest() when API-based with valid rpId from " +
+            "adaptive script param and no identified user (usernameless flow)", priority = 17)
+    public void testInitiateAuthenticationRequestApiBasedWithRpIdUsernameless() throws Exception {
+
+        AuthenticationContext context = new AuthenticationContext();
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        List<AuthenticatorConfig> authenticatorList = new ArrayList<>();
+        authenticatorList.add(authenticatorConfig);
+
+        // No authenticated user on step → getAuthenticatedUser() returns null → usernameless path.
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setAuthenticatorList(authenticatorList);
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepConfig);
+        SequenceConfig sequenceConfig = new SequenceConfig();
+        sequenceConfig.setStepMap(stepMap);
+        context.setSequenceConfig(sequenceConfig);
+        context.setServiceProviderName("TestSP");
+        context.setContextIdentifier(UUID.randomUUID().toString());
+
+        when(IdentityUtil.getPrimaryDomainName()).thenReturn(USER_STORE_DOMAIN);
+        when(IdentityUtil.getProperty(FIDOAuthenticatorConstants.WEBAUTHN_ENABLED)).thenReturn(String.valueOf(true));
+        when(httpServletRequest.getAttribute(FrameworkConstants.IS_API_BASED_AUTH_FLOW)).thenReturn(Boolean.TRUE);
+
+        Map<String, String> scriptParams = new HashMap<>();
+        scriptParams.put(FIDOAuthenticatorConstants.SCRIPT_APP_ID, "https://abcd.example.com:9443");
+        Map<String, Map<String, String>> contextParamMap = new HashMap<>();
+        contextParamMap.put(FIDOAuthenticatorConstants.AUTHENTICATOR_NAME, scriptParams);
+        context.addAuthenticatorParams(contextParamMap);
+
+        Map<String, String> parameterMap = new HashMap<>();
+        parameterMap.put(FIDOAuthenticatorConstants.APP_ID, "https://localhost:9443");
+        parameterMap.put(FIDOAuthenticatorConstants.FIDO2_AUTH, "fido2-auth");
+        authenticatorConfig.setParameterMap(parameterMap);
+
+        fileBasedConfigurationBuilderMock = mockStatic(FileBasedConfigurationBuilder.class);
+        fileBasedConfigurationBuilderMock.when(FileBasedConfigurationBuilder::getInstance)
+                .thenReturn(fileBasedConfigurationBuilder);
+        when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(authenticatorConfig);
+
+        urlEncoderMock = mockStatic(URLEncoder.class);
+        urlEncoderMock.when(() -> URLEncoder.encode(anyString(), anyString())).thenReturn("encodedUrl");
+        mockServiceURLBuilder();
+
+        try (MockedConstruction<WebAuthnService> webAuthnServiceMockedConstruction = Mockito.mockConstruction(
+                WebAuthnService.class, (mock, context1) -> {
+                    when(mock.startUsernamelessAuthenticationWithRpId(anyString(), anyString(), anyString()))
+                            .thenReturn("rpIdUsernamelessAssertionRequest");
+                })) {
+            fidoAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, context);
+
+            WebAuthnService constructedMock = webAuthnServiceMockedConstruction.constructed().get(0);
+            verify(constructedMock).startUsernamelessAuthenticationWithRpId(
+                    eq("abcd.example.com"), eq("TestSP"), eq("https://abcd.example.com:9443"));
+            verify(constructedMock, never()).startUsernamelessAuthentication(anyString());
+        }
+    }
+
+    @Test(description = "Test case for initiateAuthenticationRequest() when API-based with malformed rpId from " +
+            "adaptive script param", priority = 18)
+    public void testInitiateAuthenticationRequestApiBasedWithMalformedScriptAppId() throws Exception {
+
+        AuthenticationContext context = new AuthenticationContext();
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        authenticatorConfig.setApplicationAuthenticator(fidoAuthenticator);
+        List<AuthenticatorConfig> authenticatorList = new ArrayList<>();
+        authenticatorList.add(authenticatorConfig);
+
+        AuthenticatedUser authenticatedUser = AuthenticatedUser
+                .createLocalAuthenticatedUserFromSubjectIdentifier(USERNAME);
+        authenticatedUser.setFederatedUser(false);
+        authenticatedUser.setUserName(USERNAME);
+        authenticatedUser.setTenantDomain(SUPER_TENANT_DOMAIN);
+        authenticatedUser.setUserStoreDomain(USER_STORE_DOMAIN);
+
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setAuthenticatorList(authenticatorList);
+        stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepConfig);
+        SequenceConfig sequenceConfig = new SequenceConfig();
+        sequenceConfig.setStepMap(stepMap);
+        context.setSequenceConfig(sequenceConfig);
+        context.setSubject(authenticatedUser);
+        context.setContextIdentifier(UUID.randomUUID().toString());
+
+        when(IdentityUtil.getProperty(FIDOAuthenticatorConstants.WEBAUTHN_ENABLED)).thenReturn(String.valueOf(true));
+        when(httpServletRequest.getAttribute(FrameworkConstants.IS_API_BASED_AUTH_FLOW)).thenReturn(Boolean.TRUE);
+
+        Map<String, String> scriptParams = new HashMap<>();
+        scriptParams.put(FIDOAuthenticatorConstants.SCRIPT_APP_ID, "not-a-valid-url");
+        Map<String, Map<String, String>> contextParamMap = new HashMap<>();
+        contextParamMap.put(FIDOAuthenticatorConstants.AUTHENTICATOR_NAME, scriptParams);
+        context.addAuthenticatorParams(contextParamMap);
+
+        Map<String, String> parameterMap = new HashMap<>();
+        parameterMap.put(FIDOAuthenticatorConstants.APP_ID, "https://localhost:9443");
+        parameterMap.put(FIDOAuthenticatorConstants.FIDO2_AUTH, "fido2-auth");
+        authenticatorConfig.setParameterMap(parameterMap);
+
+        fileBasedConfigurationBuilderMock = mockStatic(FileBasedConfigurationBuilder.class);
+        fileBasedConfigurationBuilderMock.when(FileBasedConfigurationBuilder::getInstance)
+                .thenReturn(fileBasedConfigurationBuilder);
+        when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(authenticatorConfig);
+
+        try (MockedConstruction<WebAuthnService> ignored = Mockito.mockConstruction(WebAuthnService.class)) {
+            fidoAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, context);
+            Assert.fail("Expected AuthenticationFailedException was not thrown");
+        } catch (AuthenticationFailedException e) {
+            Assert.assertTrue(e.getMessage().contains("Malformed AppID value set via adaptive script parameters"));
         }
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/cache/FIDO2CacheEntry.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/cache/FIDO2CacheEntry.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019-2026, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -30,12 +30,20 @@ public class FIDO2CacheEntry extends CacheEntry {
     private String publicKeyCredentialCreationOptions;
     private URL appId;
     private String assertionRequest;
+    private String explicitRpId;
 
     public FIDO2CacheEntry(String publicKeyCredentialCreationOptions, String assertionRequest, URL appId) {
 
         this.publicKeyCredentialCreationOptions = publicKeyCredentialCreationOptions;
         this.appId = appId;
         this.assertionRequest = assertionRequest;
+    }
+
+    public FIDO2CacheEntry(String publicKeyCredentialCreationOptions, String assertionRequest, URL appId,
+                           String explicitRpId) {
+
+        this(publicKeyCredentialCreationOptions, assertionRequest, appId);
+        this.explicitRpId = explicitRpId;
     }
 
     public String getAssertionRequest() {
@@ -51,5 +59,10 @@ public class FIDO2CacheEntry extends CacheEntry {
     public URL getOrigin() {
 
         return appId;
+    }
+
+    public String getExplicitRpId() {
+
+        return explicitRpId;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) (2019-2022), WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2019-2026, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -21,7 +21,9 @@ package org.wso2.carbon.identity.application.authenticator.fido2.core;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.net.InternetDomainName;
 import com.webauthn4j.WebAuthnManager;
 import com.webauthn4j.converter.exception.DataConversionException;
@@ -125,7 +127,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.yubico.webauthn.data.UserVerificationRequirement.PREFERRED;
 import static org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2AuthenticatorConstants.APPLICATION_NAME;
@@ -651,31 +652,79 @@ public class WebAuthnService {
         URL originUrl;
         try {
             originUrl = new URL(appId);
-
             User user = new User();
             user.setUserName(username);
             user.setTenantDomain(tenantDomain);
             user.setUserStoreDomain(storeDomain);
-            if (userStorage.getFIDO2RegistrationsByUser(user).isEmpty()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("No registered device found for user :" + user.toString());
-                }
-                return null;
-            } else {
-                RelyingParty relyingParty = buildRelyingParty(originUrl);
-                AssertionRequestWrapper request = new AssertionRequestWrapper(
-                        generateRandom(),
-                        relyingParty.startAssertion(StartAssertionOptions.builder().username(user.toString()).build())
-                );
-                FIDO2Cache.getInstance().addToCacheByRequestWrapperId(
-                        new FIDO2CacheKey(request.getRequestId().getBase64()),
-                        new FIDO2CacheEntry(null, jsonMapper.writeValueAsString(request
-                                .getRequest()), originUrl));
-                return FIDOUtil.writeJson(request);
-            }
+            return doStartAuthentication(buildRelyingParty(originUrl), originUrl, user, null);
         } catch (MalformedURLException | JsonProcessingException | FIDO2AuthenticatorServerException e) {
             throw new AuthenticationFailedException(e.getMessage());
         }
+    }
+
+    /**
+     * Initiate authentication flow with an explicitly provided rpId, bypassing the servlet-hostname derivation.
+     * Used in API-based authentication flows where the rpId is resolved from operator configuration or the
+     * request Origin header.
+     *
+     * @param rpId         The relying party identifier (hostname) to use.
+     * @param rpName       The relying party display name. Passed through to the RelyingPartyIdentity.
+     * @param username     Authenticating username.
+     * @param tenantDomain Tenant domain of the user.
+     * @param storeDomain  User store domain.
+     * @param appId        Application origin URL (used for the trusted-origins set).
+     * @return JSON-serialised assertion request, or null if the user has no registered devices.
+     * @throws AuthenticationFailedException on failure.
+     */
+    public String startAuthenticationWithRpId(String rpId, String rpName, String username, String tenantDomain,
+                                              String storeDomain, String appId)
+            throws AuthenticationFailedException {
+
+        URL originUrl;
+        try {
+            originUrl = new URL(appId);
+            if (log.isDebugEnabled()) {
+                log.debug("Starting authentication with explicit rpId '" + rpId + "' for application: " + rpName);
+            }
+            User user = new User();
+            user.setUserName(username);
+            user.setTenantDomain(tenantDomain);
+            user.setUserStoreDomain(storeDomain);
+            return doStartAuthentication(buildRelyingPartyWithExplicitRpId(rpId, rpName), originUrl, user, rpId);
+        } catch (MalformedURLException | JsonProcessingException | FIDO2AuthenticatorServerException e) {
+            throw new AuthenticationFailedException(e.getMessage());
+        }
+    }
+
+    /**
+     * Shared assertion-building logic for {@link #startAuthentication} and {@link #startAuthenticationWithRpId}.
+     * Checks for registered devices, builds the assertion request, caches it, and returns the serialised form.
+     *
+     * @param relyingParty Pre-built RelyingParty (contains the rpId to use).
+     * @param originUrl    Origin URL stored in the cache entry for later finish-assertion lookup.
+     * @param user         The authenticating user.
+     * @param explicitRpId The rpId that was explicitly resolved (e.g. from SP config or Origin header), or
+     *                     {@code null} for browser-redirect flows where rpId is re-derived at finish time.
+     * @return JSON-serialised assertion request, or null if the user has no registered devices.
+     */
+    private String doStartAuthentication(RelyingParty relyingParty, URL originUrl, User user, String explicitRpId)
+            throws JsonProcessingException, FIDO2AuthenticatorServerException {
+
+        if (userStorage.getFIDO2RegistrationsByUser(user).isEmpty()) {
+            if (log.isDebugEnabled()) {
+                log.debug("No registered device found for user: " + user.toString());
+            }
+            return null;
+        }
+        AssertionRequestWrapper request = new AssertionRequestWrapper(
+                generateRandom(),
+                relyingParty.startAssertion(StartAssertionOptions.builder().username(user.toString()).build())
+        );
+        FIDO2Cache.getInstance().addToCacheByRequestWrapperId(
+                new FIDO2CacheKey(request.getRequestId().getBase64()),
+                new FIDO2CacheEntry(null,
+                        jsonMapper.writeValueAsString(request.getRequest()), originUrl, explicitRpId));
+        return FIDOUtil.writeJson(request);
     }
 
     /**
@@ -690,19 +739,74 @@ public class WebAuthnService {
         URL originUrl;
         try {
             originUrl = new URL(appId);
-            RelyingParty relyingParty = buildRelyingParty(originUrl);
-            AssertionRequestWrapper request = new AssertionRequestWrapper(generateRandom(),
-                    relyingParty.startAssertion(StartAssertionOptions.builder().build()));
-            FIDO2Cache.getInstance().addToCacheByRequestWrapperId(
-                    new FIDO2CacheKey(request.getRequestId().getBase64()),
-                    new FIDO2CacheEntry(null, jsonMapper.writeValueAsString(request
-                            .getRequest()), originUrl)
-            );
-            return FIDOUtil.writeJson(request);
+            return doStartUsernamelessAuthentication(buildRelyingParty(originUrl), originUrl, null);
         } catch (MalformedURLException | JsonProcessingException | FIDO2AuthenticatorServerException e) {
             throw new AuthenticationFailedException("Usernameless authentication initialization failed for the " +
                     "application with app id: " + appId, e);
         }
+    }
+
+    /**
+     * Initiate usernameless authentication flow with an explicitly provided rpId, bypassing the
+     * servlet-hostname derivation. Used in API-based authentication flows.
+     *
+     * @param rpId   The relying party identifier (hostname) to use.
+     * @param rpName The relying party display name.
+     * @param appId  Application origin URL (used for the trusted-origins set).
+     * @return JSON-serialised assertion request.
+     * @throws AuthenticationFailedException on failure.
+     */
+    public String startUsernamelessAuthenticationWithRpId(String rpId, String rpName, String appId)
+            throws AuthenticationFailedException {
+
+        URL originUrl;
+        try {
+            originUrl = new URL(appId);
+            if (log.isDebugEnabled()) {
+                log.debug("Starting usernameless authentication with explicit rpId '" + rpId
+                        + "' for application: " + rpName);
+            }
+            return doStartUsernamelessAuthentication(buildRelyingPartyWithExplicitRpId(rpId, rpName), originUrl, rpId);
+        } catch (MalformedURLException | JsonProcessingException | FIDO2AuthenticatorServerException e) {
+            throw new AuthenticationFailedException("Usernameless authentication initialization failed for the " +
+                    "application with app id: " + appId, e);
+        }
+    }
+
+    /**
+     * Shared assertion-building logic for {@link #startUsernamelessAuthentication} and
+     * {@link #startUsernamelessAuthenticationWithRpId}.
+     *
+     * @param relyingParty Pre-built RelyingParty (contains the rpId to use).
+     * @param originUrl    Origin URL stored in the cache entry for later finish-assertion lookup.
+     * @param explicitRpId The rpId that was explicitly resolved (e.g. from SP config or Origin header), or
+     *                     {@code null} for browser-redirect flows where rpId is re-derived at finish time.
+     * @return JSON-serialised assertion request.
+     */
+    private String doStartUsernamelessAuthentication(RelyingParty relyingParty, URL originUrl, String explicitRpId)
+            throws JsonProcessingException {
+
+        AssertionRequestWrapper request = new AssertionRequestWrapper(generateRandom(),
+                relyingParty.startAssertion(StartAssertionOptions.builder().build()));
+        FIDO2Cache.getInstance().addToCacheByRequestWrapperId(
+                new FIDO2CacheKey(request.getRequestId().getBase64()),
+                new FIDO2CacheEntry(null, jsonMapper.writeValueAsString(request.getRequest()), originUrl, explicitRpId)
+        );
+        return FIDOUtil.writeJson(request);
+    }
+
+    /**
+     * Return the currently effective trusted-origins list (combines DB and config-file sources).
+     * Callers outside this class (e.g. FIDOAuthenticator) use this to validate the request Origin header
+     * before using it for rpId resolution.
+     *
+     * @return Unmodifiable list of trusted origin strings.
+     * @throws FIDO2AuthenticatorServerException if trusted origins cannot be read.
+     */
+    public List<String> getTrustedOrigins() throws FIDO2AuthenticatorServerException {
+
+        readTrustedOrigins();
+        return Collections.unmodifiableList(origins);
     }
 
     public void finishAuthentication(String username, String tenantDomain, String storeDomain, String responseJson)
@@ -727,14 +831,21 @@ public class WebAuthnService {
         }
 
         try {
-            response = jsonMapper.readValue(responseJson, AssertionResponse.class);
+            response = jsonMapper.readValue(injectClientExtensionResults(responseJson), AssertionResponse.class);
             String requestId = response.getRequestId().getBase64();
             FIDO2CacheEntry cacheEntry = FIDO2Cache.getInstance()
                     .getValueFromCacheByRequestId(new FIDO2CacheKey(requestId));
 
             if (cacheEntry != null) {
                 request = jsonMapper.readValue(cacheEntry.getAssertionRequest(), AssertionRequest.class);
-                relyingParty = buildRelyingParty(cacheEntry.getOrigin());
+                // If an explicit rpId was stored at start time (API-based flow), use it directly so the
+                // RelyingParty matches the credential's rpIdHash.  Otherwise fall back to the legacy
+                // derivation from the cached origin URL (browser-redirect flows).
+                if (cacheEntry.getExplicitRpId() != null) {
+                    relyingParty = buildRelyingPartyWithExplicitRpId(cacheEntry.getExplicitRpId(), APPLICATION_NAME);
+                } else {
+                    relyingParty = buildRelyingParty(cacheEntry.getOrigin());
+                }
                 FIDO2Cache.getInstance().clearCacheEntryByRequestId(new FIDO2CacheKey(requestId));
             }
         } catch (IOException e) {
@@ -795,7 +906,14 @@ public class WebAuthnService {
         AssertionRequest request = getAssertionRequest(cacheEntry);
         RelyingParty relyingParty = null;
         try {
-            relyingParty = buildRelyingParty(cacheEntry.getOrigin());
+            // If an explicit rpId was stored at start time (API-based flow), use it directly so the
+            // RelyingParty matches the credential's rpIdHash.  Otherwise fall back to the legacy
+            // derivation from the cached origin URL (browser-redirect flows).
+            if (cacheEntry.getExplicitRpId() != null) {
+                relyingParty = buildRelyingPartyWithExplicitRpId(cacheEntry.getExplicitRpId(), APPLICATION_NAME);
+            } else {
+                relyingParty = buildRelyingParty(cacheEntry.getOrigin());
+            }
         } catch (FIDO2AuthenticatorServerException e) {
             throw new AuthenticationFailedException("Server error when building relying party for request ID: ",
                     requestId, e);
@@ -1056,7 +1174,6 @@ public class WebAuthnService {
 
     private RelyingParty buildRelyingParty(URL originUrl) throws FIDO2AuthenticatorServerException {
 
-        readTrustedOrigins();
         String rpId;
 
         try {
@@ -1076,7 +1193,29 @@ public class WebAuthnService {
             rpId = originUrl.getHost();
         }
 
-        RelyingPartyIdentity rpIdentity = RelyingPartyIdentity.builder().id(rpId).name(APPLICATION_NAME).build();
+        return buildRelyingPartyWithExplicitRpId(rpId, APPLICATION_NAME);
+    }
+
+    /**
+     * Build a RelyingParty with an explicitly provided rpId and rp name, bypassing the hostname-derivation logic.
+     * Used in API-based authentication flows where the rpId is resolved from operator configuration or the
+     * request Origin header rather than from the IS servlet hostname.
+     *
+     * @param rpId   The relying party identifier (hostname) to use directly.
+     * @param rpName The relying party display name. Falls back to APPLICATION_NAME if blank.
+     * @return A configured RelyingParty instance.
+     * @throws FIDO2AuthenticatorServerException if trusted origins cannot be read.
+     */
+    private RelyingParty buildRelyingPartyWithExplicitRpId(String rpId, String rpName)
+            throws FIDO2AuthenticatorServerException {
+
+        readTrustedOrigins();
+        String resolvedRpName = StringUtils.isNotBlank(rpName) ? rpName : APPLICATION_NAME;
+
+        RelyingPartyIdentity rpIdentity = RelyingPartyIdentity.builder()
+                .id(rpId)
+                .name(resolvedRpName)
+                .build();
 
         List<PublicKeyCredentialParameters> preferredPublicKeyCredentialParameters = Collections.unmodifiableList(
                 Arrays.asList(PublicKeyCredentialParameters.ES256, PublicKeyCredentialParameters.EdDSA,
@@ -1302,7 +1441,7 @@ public class WebAuthnService {
          * string.
          */
         List<String> updatedOrigins = origins.stream()
-                .flatMap(url -> Stream.of(removeDefaultPort(url), appendDefaultPortIfAbsent(url))).distinct()
+                .flatMap(url -> Arrays.stream(new String[]{removeDefaultPort(url), appendDefaultPortIfAbsent(url)})).distinct()
                 .collect(Collectors.toList());
 
         origins.clear();
@@ -1371,6 +1510,36 @@ public class WebAuthnService {
         return credential;
     }
 
+    /**
+     * Ensures the assertion response JSON contains a {@code clientExtensionResults} object inside the
+     * {@code credential} node.  The browser's WebAuthn API omits this field when no extensions are
+     * requested, but Yubico's {@link PublicKeyCredential} marks it {@code @NonNull}.  Without this
+     * pre-processing Jackson would throw a {@code NullPointerException} (wrapped as
+     * {@code JsonMappingException}) when deserialising the credential, which surfaces as
+     * "Failed to decode response object."
+     *
+     * @param responseJson The raw assertion response JSON string.
+     * @return The (possibly modified) JSON string that always has {@code clientExtensionResults: {}}.
+     */
+    private String injectClientExtensionResults(String responseJson) {
+
+        try {
+            JsonNode root = jsonMapper.readTree(responseJson);
+            if (root.isObject() && root.has("credential")) {
+                JsonNode credentialNode = root.get("credential");
+                if (credentialNode.isObject() && !credentialNode.has("clientExtensionResults")) {
+                    ((ObjectNode) credentialNode).set("clientExtensionResults", jsonMapper.createObjectNode());
+                    return jsonMapper.writeValueAsString(root);
+                }
+            }
+        } catch (IOException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Could not pre-process assertion response JSON to inject clientExtensionResults.", e);
+            }
+        }
+        return responseJson;
+    }
+
     private AssertionResponse getAssertionResponse(String responseJson) throws AuthenticationFailedException {
 
         final AssertionResponse response;
@@ -1385,7 +1554,7 @@ public class WebAuthnService {
         }
 
         try {
-            response = jsonMapper.readValue(responseJson, AssertionResponse.class);
+            response = jsonMapper.readValue(injectClientExtensionResults(responseJson), AssertionResponse.class);
         } catch (IOException e) {
             throw new AuthenticationFailedException("Assertion for finish authentication flow failed due to failure " +
                     "in decoding json response: " + responseJson, e);

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnServiceTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnServiceTest.java
@@ -247,6 +247,10 @@ public class WebAuthnServiceTest {
         jacksonCodecsMock = Mockito.mockStatic(JacksonCodecs.class);
         jacksonCodecsMock.when(JacksonCodecs::json).thenReturn(objectMapperMock);
 
+        // Stub readTree to throw JsonProcessingException (declared by readTree) so that
+        // injectClientExtensionResults() catches it (via IOException supertype) and returns the original JSON unchanged.
+        when(objectMapperMock.readTree(anyString())).thenThrow(new JsonProcessingException("mock") {});
+
         webAuthnService = new WebAuthnService();
 
         when(FIDO2DeviceStoreDAO.getInstance()).thenReturn(fido2DeviceStoreDAO);
@@ -344,19 +348,19 @@ public class WebAuthnServiceTest {
     @AfterMethod
     public void tearDown() {
 
-        fido2DeviceStoreDAOMock.close();
-        identityUtilMock.close();
-        jacksonCodecsMock.close();
-        identityConfigParserMock.close();
-        userCoreUtilMock.close();
-        userMock.close();
-        relyingPartyMock.close();
-        fido2CacheMock.close();
-        identityTenantUtilMock.close();
-        fido2AuthenticatorServiceComponentMock.close();
-        internetDomainNameMock.close();
-        fido2AuthenticatorServiceDataHolderMock.close();
-        fidoUtilMock.close();
+        if (fido2DeviceStoreDAOMock != null) fido2DeviceStoreDAOMock.close();
+        if (identityUtilMock != null) identityUtilMock.close();
+        if (jacksonCodecsMock != null) jacksonCodecsMock.close();
+        if (identityConfigParserMock != null) identityConfigParserMock.close();
+        if (userCoreUtilMock != null) userCoreUtilMock.close();
+        if (userMock != null) userMock.close();
+        if (relyingPartyMock != null) relyingPartyMock.close();
+        if (fido2CacheMock != null) fido2CacheMock.close();
+        if (identityTenantUtilMock != null) identityTenantUtilMock.close();
+        if (fido2AuthenticatorServiceComponentMock != null) fido2AuthenticatorServiceComponentMock.close();
+        if (internetDomainNameMock != null) internetDomainNameMock.close();
+        if (fido2AuthenticatorServiceDataHolderMock != null) fido2AuthenticatorServiceDataHolderMock.close();
+        if (fidoUtilMock != null) fidoUtilMock.close();
         if (privilegedCarbonContextMock != null) {
             privilegedCarbonContextMock.close();
         }
@@ -819,6 +823,228 @@ public class WebAuthnServiceTest {
             trustedOrigins.clear();
             trustedOrigins.add(ORIGIN);
             identityConfig.put(FIDO2AuthenticatorConstants.TRUSTED_ORIGINS, trustedOrigins);
+        }
+    }
+
+    @Test(description = "Test case for startAuthenticationWithRpId() method", priority = 15)
+    public void testStartAuthenticationWithRpId() throws AuthenticationFailedException {
+
+        try (MockedStatic<StartAssertionOptions> startAssertionOptionsMock =
+                     Mockito.mockStatic(StartAssertionOptions.class)) {
+            StartAssertionOptions.StartAssertionOptionsBuilder startAssertionOptionsBuilder =
+                    mock(StartAssertionOptions.StartAssertionOptionsBuilder.class);
+            startAssertionOptionsMock.when(StartAssertionOptions::builder).thenReturn(startAssertionOptionsBuilder);
+            when(startAssertionOptionsBuilder.username(anyString())).thenReturn(startAssertionOptionsBuilder);
+            StartAssertionOptions startAssertionOptions = mock(StartAssertionOptions.class);
+            when(startAssertionOptionsBuilder.build()).thenReturn(startAssertionOptions);
+            when(relyingParty.startAssertion(any(StartAssertionOptions.class))).thenReturn(assertionRequest);
+            fidoUtilMock.when(() -> FIDOUtil.writeJson(any(AssertionRequestWrapper.class)))
+                    .thenReturn("assertionRequest");
+
+            String response = webAuthnService.startAuthenticationWithRpId(
+                    "localhost", "Test App", USERNAME, TENANT_DOMAIN, USER_STORE_DOMAIN, ORIGIN);
+            Assert.assertEquals(response, "assertionRequest");
+        }
+    }
+
+    @Test(description = "Test case for startUsernamelessAuthenticationWithRpId() method", priority = 16)
+    public void testStartUsernamelessAuthenticationWithRpId() throws AuthenticationFailedException {
+
+        try (MockedStatic<StartAssertionOptions> startAssertionOptionsMock =
+                     Mockito.mockStatic(StartAssertionOptions.class)) {
+            StartAssertionOptions.StartAssertionOptionsBuilder startAssertionOptionsBuilder =
+                    mock(StartAssertionOptions.StartAssertionOptionsBuilder.class);
+            startAssertionOptionsMock.when(StartAssertionOptions::builder).thenReturn(startAssertionOptionsBuilder);
+            StartAssertionOptions startAssertionOptions = mock(StartAssertionOptions.class);
+            when(startAssertionOptionsBuilder.build()).thenReturn(startAssertionOptions);
+            when(relyingParty.startAssertion(any(StartAssertionOptions.class))).thenReturn(assertionRequest);
+            fidoUtilMock.when(() -> FIDOUtil.writeJson(any(AssertionRequestWrapper.class)))
+                    .thenReturn("assertionRequest");
+
+            String response = webAuthnService.startUsernamelessAuthenticationWithRpId(
+                    "localhost", "Test App", ORIGIN);
+            Assert.assertEquals(response, "assertionRequest");
+        }
+    }
+
+    @Test(description = "Test case for getTrustedOrigins() method", priority = 17)
+    public void testGetTrustedOrigins() throws FIDO2AuthenticatorServerException {
+
+        List<String> result = webAuthnService.getTrustedOrigins();
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertTrue(result.contains(ORIGIN));
+    }
+
+    @Test(description = "Test case for finishAuthentication() with explicit rpId when assertion success",
+            priority = 18)
+    public void testFinishAuthenticationWithExplicitRpIdSuccessfulAssertion() throws JsonProcessingException,
+            MalformedURLException, AuthenticationFailedException, AssertionFailedException {
+
+        when(objectMapperMock.readValue(finishAuthenticationResponseString, AssertionResponse.class))
+                .thenReturn(finishAuthenticationResponse);
+        when(fido2Cache.getValueFromCacheByRequestId(any(FIDO2CacheKey.class))).thenReturn(fido2CacheEntry);
+        when(fido2CacheEntry.getAssertionRequest()).thenReturn("assertionRequest");
+        when(fido2CacheEntry.getExplicitRpId()).thenReturn("localhost");
+        when(objectMapperMock.readValue("assertionRequest", AssertionRequest.class)).thenReturn(assertionRequest);
+        when(relyingParty.finishAssertion(any(FinishAssertionOptions.class))).thenReturn(assertionResult);
+        when(assertionResult.isSuccess()).thenReturn(true);
+        when(assertionResult.getUsername()).thenReturn(USERNAME);
+
+        webAuthnService.finishAuthentication(USERNAME, TENANT_DOMAIN, USER_STORE_DOMAIN,
+                finishAuthenticationResponseString);
+    }
+
+    @Test(description = "Test case for finishAuthentication() with explicit rpId when assertion fails",
+            expectedExceptions = {AuthenticationFailedException.class}, priority = 19)
+    public void testFinishAuthenticationWithExplicitRpIdFailedAssertion() throws JsonProcessingException,
+            MalformedURLException, AuthenticationFailedException, AssertionFailedException {
+
+        when(objectMapperMock.readValue(finishAuthenticationResponseString, AssertionResponse.class))
+                .thenReturn(finishAuthenticationResponse);
+        when(fido2Cache.getValueFromCacheByRequestId(any(FIDO2CacheKey.class))).thenReturn(fido2CacheEntry);
+        when(fido2CacheEntry.getAssertionRequest()).thenReturn("assertionRequest");
+        when(fido2CacheEntry.getExplicitRpId()).thenReturn("localhost");
+        when(objectMapperMock.readValue("assertionRequest", AssertionRequest.class)).thenReturn(assertionRequest);
+        when(relyingParty.finishAssertion(any(FinishAssertionOptions.class))).thenReturn(assertionResult);
+        when(assertionResult.isSuccess()).thenReturn(false);
+        when(assertionResult.getUsername()).thenReturn(USERNAME);
+
+        webAuthnService.finishAuthentication(USERNAME, TENANT_DOMAIN, USER_STORE_DOMAIN,
+                finishAuthenticationResponseString);
+    }
+
+    @Test(description = "Test case for finishUsernamelessAuthentication() with explicit rpId when assertion success",
+            priority = 20)
+    public void testFinishUsernamelessAuthenticationWithExplicitRpIdSuccessfulAssertion()
+            throws JsonProcessingException, AuthenticationFailedException, MalformedURLException,
+            AssertionFailedException {
+
+        when(objectMapperMock.readValue(finishUsernamelessAuthenticationResponseString, AssertionResponse.class))
+                .thenReturn(finishUsernamelessAuthenticationResponse);
+        when(fido2Cache.getValueFromCacheByRequestId(any(FIDO2CacheKey.class))).thenReturn(fido2CacheEntry);
+        when(fido2CacheEntry.getAssertionRequest()).thenReturn("assertionRequest");
+        when(fido2CacheEntry.getExplicitRpId()).thenReturn("localhost");
+        when(objectMapperMock.readValue("assertionRequest", AssertionRequest.class)).thenReturn(assertionRequest);
+        when(relyingParty.finishAssertion(any(FinishAssertionOptions.class))).thenReturn(assertionResult);
+        when(assertionResult.isSuccess()).thenReturn(true);
+        when(assertionResult.getUsername()).thenReturn(USERNAME);
+
+        AuthenticatedUser authenticatedUserResponse = webAuthnService.finishUsernamelessAuthentication(
+                finishUsernamelessAuthenticationResponseString);
+        Assert.assertEquals(authenticatedUserResponse.getUserName(), user.getUserName());
+        Assert.assertEquals(authenticatedUserResponse.getTenantDomain(), user.getTenantDomain());
+        Assert.assertEquals(authenticatedUserResponse.getUserStoreDomain(), user.getUserStoreDomain());
+    }
+
+    @Test(description = "Test case for finishUsernamelessAuthentication() with explicit rpId when assertion fails",
+            expectedExceptions = {AuthenticationFailedException.class}, priority = 21)
+    public void testFinishUsernamelessAuthenticationWithExplicitRpIdFailedAssertion()
+            throws JsonProcessingException, AuthenticationFailedException, MalformedURLException,
+            AssertionFailedException {
+
+        when(objectMapperMock.readValue(finishUsernamelessAuthenticationResponseString, AssertionResponse.class))
+                .thenReturn(finishUsernamelessAuthenticationResponse);
+        when(fido2Cache.getValueFromCacheByRequestId(any(FIDO2CacheKey.class))).thenReturn(fido2CacheEntry);
+        when(fido2CacheEntry.getAssertionRequest()).thenReturn("assertionRequest");
+        when(fido2CacheEntry.getExplicitRpId()).thenReturn("localhost");
+        when(objectMapperMock.readValue("assertionRequest", AssertionRequest.class)).thenReturn(assertionRequest);
+        when(relyingParty.finishAssertion(any(FinishAssertionOptions.class))).thenReturn(assertionResult);
+        when(assertionResult.isSuccess()).thenReturn(false);
+        when(assertionResult.getUsername()).thenReturn(USERNAME);
+
+        webAuthnService.finishUsernamelessAuthentication(finishUsernamelessAuthenticationResponseString);
+    }
+
+    @Test(description = "Test case for deregisterFIDO2Credential() with username parameter", priority = 22)
+    public void testDeregisterFIDO2CredentialWithUsername() throws FIDO2AuthenticatorServerException,
+            FIDO2AuthenticatorClientException {
+
+        webAuthnService.deregisterFIDO2Credential(CREDENTIAL_ID, TENANT_QUALIFIED_USERNAME);
+    }
+
+    @Test(description = "Test case for updateFIDO2DeviceDisplayName() with username parameter", priority = 23)
+    public void testUpdateFIDO2DeviceDisplayNameWithUsername() throws FIDO2AuthenticatorServerException,
+            FIDO2AuthenticatorClientException {
+
+        webAuthnService.updateFIDO2DeviceDisplayName(CREDENTIAL_ID, "Updated display name",
+                TENANT_QUALIFIED_USERNAME);
+    }
+
+    @Test(description = "Test case for createFIDO2Credential() method", priority = 24)
+    public void testCreateFIDO2Credential() throws Exception {
+
+        when(objectMapperMock.readValue(finishRegistrationResponseString, RegistrationResponse.class))
+                .thenReturn(finishRegistrationResponse);
+        when(fido2DeviceStoreDAO.getFIDO2RegistrationByUsernameAndCredentialId(anyString(), any(ByteArray.class)))
+                .thenReturn(Optional.empty());
+        when(fido2Cache.getValueFromCacheByRequestId(any(FIDO2CacheKey.class))).thenReturn(fido2CacheEntry);
+        when(fido2CacheEntry.getPublicKeyCredentialCreationOptions())
+                .thenReturn("publicKeyCredentialCreationOptions");
+        when(objectMapperMock.readValue("publicKeyCredentialCreationOptions",
+                PublicKeyCredentialCreationOptions.class)).thenReturn(publicKeyCredentialCreationOptions);
+        when(fido2CacheEntry.getOrigin()).thenReturn(new URL(ORIGIN));
+        when(configurationManager.getAttribute(FIDO_CONFIG_RESOURCE_TYPE_NAME, FIDO2_CONFIG_RESOURCE_NAME,
+                FIDO2_CONFIG_ATTESTATION_VALIDATION_ATTRIBUTE_NAME)).thenReturn(
+                new Attribute(FIDO2_CONFIG_ATTESTATION_VALIDATION_ATTRIBUTE_NAME, "false"));
+        when(configurationManager.getAttribute(FIDO_CONFIG_RESOURCE_TYPE_NAME, FIDO2_CONFIG_RESOURCE_NAME,
+                FIDO2_CONFIG_MDS_VALIDATION_ATTRIBUTE_NAME)).thenReturn(
+                new Attribute(FIDO2_CONFIG_MDS_VALIDATION_ATTRIBUTE_NAME, "false"));
+
+        try (MockedStatic<FinishRegistrationOptions> finishRegistrationOptionsMock =
+                     Mockito.mockStatic(FinishRegistrationOptions.class);
+             MockedStatic<RegisteredCredential> registeredCredentialMock =
+                     Mockito.mockStatic(RegisteredCredential.class)) {
+            FinishRegistrationOptions finishRegistrationOptions = mock(FinishRegistrationOptions.class);
+            FinishRegistrationOptions.FinishRegistrationOptionsBuilder finishRegistrationOptionsBuilder =
+                    mock(FinishRegistrationOptions.FinishRegistrationOptionsBuilder.class);
+            FinishRegistrationOptions.FinishRegistrationOptionsBuilder.MandatoryStages mandatoryStages1 =
+                    mock(FinishRegistrationOptions.FinishRegistrationOptionsBuilder.MandatoryStages.class);
+            FinishRegistrationOptions.FinishRegistrationOptionsBuilder.MandatoryStages.Step2 step2Finish =
+                    mock(FinishRegistrationOptions.FinishRegistrationOptionsBuilder.MandatoryStages.Step2.class);
+
+            finishRegistrationOptionsMock.when(FinishRegistrationOptions::builder).thenReturn(mandatoryStages1);
+            when(mandatoryStages1.request(any(PublicKeyCredentialCreationOptions.class))).thenReturn(step2Finish);
+            when(step2Finish.response(any(PublicKeyCredential.class))).thenReturn(finishRegistrationOptionsBuilder);
+            when(finishRegistrationOptionsBuilder.build()).thenReturn(finishRegistrationOptions);
+
+            when(relyingParty.finishRegistration(any(FinishRegistrationOptions.class))).thenReturn(registrationResult);
+            PublicKeyCredentialDescriptor descriptor = mock(PublicKeyCredentialDescriptor.class);
+            ByteArray byteArray = new ByteArray(new byte[]{});
+            UserIdentity userIdentity = mock(UserIdentity.class);
+            when(registrationResult.getKeyId()).thenReturn(descriptor);
+            when(descriptor.getId()).thenReturn(byteArray);
+            when(registrationResult.getPublicKeyCose()).thenReturn(byteArray);
+            when(publicKeyCredentialCreationOptions.getUser()).thenReturn(userIdentity);
+            when(userIdentity.getId()).thenReturn(byteArray);
+            AuthenticatorSelectionCriteria authenticatorSelectionCriteria =
+                    mock(AuthenticatorSelectionCriteria.class);
+            when(publicKeyCredentialCreationOptions.getAuthenticatorSelection()).thenReturn(
+                    Optional.of(authenticatorSelectionCriteria));
+            when(authenticatorSelectionCriteria.getResidentKey()).thenReturn(
+                    Optional.of(ResidentKeyRequirement.DISCOURAGED));
+
+            RegisteredCredential registeredCredential = mock(RegisteredCredential.class);
+            RegisteredCredential.RegisteredCredentialBuilder registeredCredentialBuilder =
+                    mock(RegisteredCredential.RegisteredCredentialBuilder.class);
+            RegisteredCredential.RegisteredCredentialBuilder.MandatoryStages mandatoryStages2 =
+                    mock(RegisteredCredential.RegisteredCredentialBuilder.MandatoryStages.class);
+            RegisteredCredential.RegisteredCredentialBuilder.MandatoryStages.Step2 step2RegisteredCredentials =
+                    mock(RegisteredCredential.RegisteredCredentialBuilder.MandatoryStages.Step2.class);
+            RegisteredCredential.RegisteredCredentialBuilder.MandatoryStages.Step3 step3RegisteredCredentials =
+                    mock(RegisteredCredential.RegisteredCredentialBuilder.MandatoryStages.Step3.class);
+
+            registeredCredentialMock.when(RegisteredCredential::builder).thenReturn(mandatoryStages2);
+            when(mandatoryStages2.credentialId(any(ByteArray.class))).thenReturn(step2RegisteredCredentials);
+            when(step2RegisteredCredentials.userHandle(any(ByteArray.class))).thenReturn(step3RegisteredCredentials);
+            when(step3RegisteredCredentials.publicKeyCose(any(ByteArray.class)))
+                    .thenReturn(registeredCredentialBuilder);
+            when(registeredCredentialBuilder.signatureCount(anyLong())).thenReturn(registeredCredentialBuilder);
+            when(registeredCredentialBuilder.build()).thenReturn(registeredCredential);
+
+            FIDO2CredentialRegistration result = webAuthnService.createFIDO2Credential(
+                    finishRegistrationResponseString, TENANT_QUALIFIED_USERNAME);
+            Assert.assertNotNull(result);
         }
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/FIDO2ExecutorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/FIDO2ExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request enhances the FIDO authenticator to better support API-based authentication flows, particularly for FIDO2/WebAuthn, by allowing the relying party ID (`rpId`) and effective AppID to be dynamically resolved from adaptive script parameters. The changes ensure that API-based and browser-based flows are handled appropriately and add robustness to the initialization and test code.

**Enhancements for API-Based Authentication Flows:**

* Updated `FIDOAuthenticator` to resolve `rpId` and effective `AppID` from adaptive script parameters during API-based authentication flows, enabling more flexible and dynamic configuration. This includes error handling for malformed AppID values and proper fallback to default values. [[1]](diffhunk://#diff-441b3425fb5569f166eede456af9ce3e05ce43af3d5e6aa932eb82f5c88e44c3L832-R835) [[2]](diffhunk://#diff-441b3425fb5569f166eede456af9ce3e05ce43af3d5e6aa932eb82f5c88e44c3R855-R897)
* Modified the `initiateFido2AuthenticationRequest` and `getRedirectUrl` methods to accept and use an `isAPIBased` parameter, ensuring correct logic depending on the authentication flow type. [[1]](diffhunk://#diff-441b3425fb5569f166eede456af9ce3e05ce43af3d5e6aa932eb82f5c88e44c3R692-R694) [[2]](diffhunk://#diff-441b3425fb5569f166eede456af9ce3e05ce43af3d5e6aa932eb82f5c88e44c3L936-R981)
* Added the constant `SCRIPT_APP_ID` to `FIDOAuthenticatorConstants` for use with adaptive script parameters.

**Code Quality and Maintenance:**

* Updated copyright years to 2026 in source and test files. [[1]](diffhunk://#diff-441b3425fb5569f166eede456af9ce3e05ce43af3d5e6aa932eb82f5c88e44c3L2-R2) [[2]](diffhunk://#diff-9e4bd04457d7ae364ae501cf43293d1ccb9d2a50253c8101304dca6aa6cad820L2-R2) [[3]](diffhunk://#diff-0c63c893b28e09f249b84180bf0ef19015a9f4dc132851130353952ed2826f9aL2-R2)
* Standardized usage of `mockStatic` from Mockito in test code for improved readability and consistency. [[1]](diffhunk://#diff-0c63c893b28e09f249b84180bf0ef19015a9f4dc132851130353952ed2826f9aL128-R134) [[2]](diffhunk://#diff-0c63c893b28e09f249b84180bf0ef19015a9f4dc132851130353952ed2826f9aL215-R218) [[3]](diffhunk://#diff-0c63c893b28e09f249b84180bf0ef19015a9f4dc132851130353952ed2826f9aL379-R384) [[4]](diffhunk://#diff-0c63c893b28e09f249b84180bf0ef19015a9f4dc132851130353952ed2826f9aL456-R464) [[5]](diffhunk://#diff-0c63c893b28e09f249b84180bf0ef19015a9f4dc132851130353952ed2826f9aL529-R534) [[6]](diffhunk://#diff-0c63c893b28e09f249b84180bf0ef19015a9f4dc132851130353952ed2826f9aL544-R552) [[7]](diffhunk://#diff-0c63c893b28e09f249b84180bf0ef19015a9f4dc132851130353952ed2826f9aL696-R700)

### Related Issues

- https://github.com/wso2/product-is/issues/26551

### Related PRs

- https://github.com/wso2-support/identity-local-auth-fido/pull/95

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
