### PR TITLE
Improve user store domain resolution in FIDO2 flow executor

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/FIDO2Executor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/FIDO2Executor.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2A
 import org.wso2.carbon.identity.application.authenticator.fido2.util.Either;
 import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2ExecutorConstants;
 import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDOUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
 import org.wso2.carbon.identity.flow.execution.engine.graph.AuthenticationExecutor;
 import org.wso2.carbon.identity.flow.execution.engine.graph.Executor;
@@ -111,7 +112,7 @@ public class FIDO2Executor extends AuthenticationExecutor {
                 JsonObject credentialObject = (JsonObject) JsonParser.parseString(credential);
                 challengeResponse.add(FIDO2ExecutorConstants.REQUEST_ID, JsonParser.parseString(requestId));
                 challengeResponse.add(FIDO2ExecutorConstants.CREDENTIAL, credentialObject);
-                // Add tenant domain to the username.
+                username = IdentityUtil.addDomainToName(username, context.getFlowUser().getUserStoreDomain());
                 username = UserCoreUtil.addTenantDomainToEntry(username, context.getTenantDomain());
                 if (FIDOUtil.isRegistrationFlow(context)) {
                     FIDO2CredentialRegistration registration = webAuthnService

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/RegistrationFlowCompletionListener.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/executor/RegistrationFlowCompletionListener.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2A
 import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2ExecutorConstants;
 import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDOUtil;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
 import org.wso2.carbon.identity.flow.execution.engine.listener.AbstractFlowExecutionListener;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
@@ -81,6 +82,7 @@ public class RegistrationFlowCompletionListener extends AbstractFlowExecutionLis
                     });
             try {
                 String username = context.getFlowUser().getUsername();
+                username = IdentityUtil.addDomainToName(username, context.getFlowUser().getUserStoreDomain());
                 username = UserCoreUtil.addTenantDomainToEntry(username, context.getTenantDomain());
                 FIDO2DeviceStoreDAO.getInstance().addFIDO2RegistrationByUsername(username,
                         buildFromMap(credentialRegistration));


### PR DESCRIPTION
## Purpose

Improve how the user store domain is resolved when FIDO2 passkeys are registered and removed through the flow execution engine (e.g. self-registration / passkey enrollment flows).

Previously the FIDO2 flow executor and the registration completion listener built the persistence key from the flow user's username and the **tenant** domain only. `FlowUser` tracks the user store domain in a separate field (`FlowUser#getUserStoreDomain()`), which was not applied — so the credential's `DOMAIN_NAME` resolved via `User.getUserFromUserName(...)` always defaulted to `PRIMARY`, even when the user belonged to a secondary user store.

## Changes

- `FIDO2Executor#processFIDO2` — qualify the username with the user store domain (when present) in addition to the tenant domain before creating / finishing the credential.
- `FIDO2Executor#rollback` — apply the same qualification so the correct credential is located and deregistered during rollback.
- `RegistrationFlowCompletionListener#doPostExecute` — qualify the username before persisting the registration via `FIDO2DeviceStoreDAO#addFIDO2RegistrationByUsername`.
- Domain qualification uses `IdentityUtil.addDomainToName(...)`, which is a no-op for the `PRIMARY` domain, preserving existing behaviour for primary-store users.

## Related

- Updated `FIDO2ExecutorTest#testRollbackWithError` to stub the tenant domain, matching the qualified-username path now exercised by rollback.

Issue https://github.com/wso2/product-is/issues/27989

## Testing

- `mvn clean install` on `org.wso2.carbon.identity.application.authenticator.fido2` — all unit tests pass (42/42).