### PR TITLE
[identity-local-auth-fido] Bump Jackson to 2.21.2

### DIFF
--- a/features/org.wso2.carbon.identity.application.authenticator.fido2.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.application.authenticator.fido2.server.feature/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
+            <version>${fasterxml.jackson.annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${fasterxml.jackson.version}</version>
+                <version>${fasterxml.jackson.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -413,8 +413,9 @@
         <identity.extension.utils.import.version.range>[1.0.8,2.0.0)</identity.extension.utils.import.version.range>
         <com.yubico.version>0.14.0</com.yubico.version>
         <google.guava.version>33.0.0-jre</google.guava.version>
-        <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
-        <jackson-databind.version>2.18.6</jackson-databind.version>
+        <fasterxml.jackson.version>2.21.2</fasterxml.jackson.version>
+        <fasterxml.jackson.annotations.version>2.21</fasterxml.jackson.annotations.version>
+        <jackson-databind.version>2.21.2</jackson-databind.version>
         <bcprov.version>1.49.0.wso2v2</bcprov.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <imp.pkg.version.javax.servlet>[3.1.0, 4.0.0)</imp.pkg.version.javax.servlet>


### PR DESCRIPTION
## Purpose
Upgrade Jackson Databind and related libraries to the latest stable 2.21.x release.

## Goals
- Align all Jackson artifacts to a consistent 2.21.x baseline across the IS dependency tree
- Replace the 2.18.x versions that are no longer receiving upstream fixes

## Approach
Version property bumps only — no code or logic changes. The following properties were updated in the root `pom.xml`:
- `fasterxml.jackson.version` → `2.21.2`
- `jackson-databind.version` → `2.21.2`

### Related PRs
 - https://github.com/wso2-extensions/identity-local-auth-fido/pull/178