### PR TITLE
[identity-local-auth-fido] [Revert] Jackson upgrade to 2.21.2

### DIFF
--- a/features/org.wso2.carbon.identity.application.authenticator.fido2.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.application.authenticator.fido2.server.feature/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.annotations.version}</version>
+            <version>${fasterxml.jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${fasterxml.jackson.annotations.version}</version>
+                <version>${fasterxml.jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -413,9 +413,8 @@
         <identity.extension.utils.import.version.range>[1.0.8,2.0.0)</identity.extension.utils.import.version.range>
         <com.yubico.version>0.14.0</com.yubico.version>
         <google.guava.version>33.0.0-jre</google.guava.version>
-        <fasterxml.jackson.version>2.21.2</fasterxml.jackson.version>
-        <fasterxml.jackson.annotations.version>2.21</fasterxml.jackson.annotations.version>
-        <jackson-databind.version>2.21.2</jackson-databind.version>
+        <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
+        <jackson-databind.version>2.18.6</jackson-databind.version>
         <bcprov.version>1.49.0.wso2v2</bcprov.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <imp.pkg.version.javax.servlet>[3.1.0, 4.0.0)</imp.pkg.version.javax.servlet>


### PR DESCRIPTION
### Purpose
Revert the Jackson upgrade introduced in [[1]](https://github.com/wso2-extensions/identity-local-auth-fido/pull/177).

### Goals
- Remove the dependency on `jackson-annotations 2.21.2`, which does not exist on Maven Central — the `jackson-annotations` artifact only releases at minor versions (e.g. `2.21`, `2.22`) with no patch suffixes
- Resolve the Maven build failure caused by an unresolvable `jackson-annotations:2.21.2` artifact
- Avoid the OSGi version constraint mismatch introduced by splitting annotations to `2.21` while keeping `jackson-core/databind` at `2.21.2`

### Approach
- Revert `fasterxml.jackson.version` from `2.21.2` → `2.18.6`
- Revert `jackson-databind.version` from `2.21.2` → `2.18.6`
- Remove `fasterxml.jackson.annotations.version` property
- Restore `jackson-annotations` to use `${fasterxml.jackson.version}` in both root `pom.xml` and `fido2.server.feature/pom.xml`

### Related PRs

- [1] https://github.com/wso2-extensions/identity-local-auth-fido/pull/177
