### PR TITLE
Normalize passkey username case for Identifier First bypass on case-insensitive user stores

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -68,6 +68,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -1414,6 +1415,19 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                     secondary = secondary.getSecondaryUserStoreManager();
                 }
             }
+
+            // On a case-insensitive store, resolve the username to the case under which the passkey was
+            // enrolled so a case-differing authorize `username` param (which bypasses Identifier First)
+            // still matches the stored passkey.
+            String caseDomain = StringUtils.isNotBlank(userStoreDomain)
+                    ? userStoreDomain : UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
+            if (!IdentityUtil.isUserStoreCaseSensitive(caseDomain, tenantId)) {
+                String storedUsername = resolveStoredPasskeyUsername(
+                        FIDOUtil.getUsernameWithoutDomain(username), tenantDomain, userStoreDomain);
+                if (StringUtils.isNotBlank(storedUsername)) {
+                    username = storedUsername;
+                }
+            }
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             if (log.isDebugEnabled()) {
                 log.debug("FIDO Authenticator failed while trying to authenticate.", e);
@@ -1427,6 +1441,17 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         }
 
         return authenticatedUser;
+    }
+
+    private String resolveStoredPasskeyUsername(String username, String tenantDomain, String userStoreDomain)
+            throws AuthenticationFailedException {
+
+        try {
+            return new WebAuthnService().resolveStoredUsername(username, tenantDomain, userStoreDomain);
+        } catch (FIDO2AuthenticatorServerException e) {
+            throw new AuthenticationFailedException(
+                    "Error while resolving the stored passkey username for: " + username, e);
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -68,7 +68,6 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.user.api.UserRealm;
-import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -1420,7 +1419,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             // enrolled so a case-differing authorize `username` param (which bypasses Identifier First)
             // still matches the stored passkey.
             String caseDomain = StringUtils.isNotBlank(userStoreDomain)
-                    ? userStoreDomain : UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
+                    ? userStoreDomain : IdentityUtil.getPrimaryDomainName();
             if (!IdentityUtil.isUserStoreCaseSensitive(caseDomain, tenantId)) {
                 String storedUsername = resolveStoredPasskeyUsername(
                         FIDOUtil.getUsernameWithoutDomain(username), tenantDomain, userStoreDomain);
@@ -1450,7 +1449,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             return new WebAuthnService().resolveStoredUsername(username, tenantDomain, userStoreDomain);
         } catch (FIDO2AuthenticatorServerException e) {
             throw new AuthenticationFailedException(
-                    "Error while resolving the stored passkey username for: " + username, e);
+                    "Error while resolving the stored passkey username for: " + getMaskedUsername(username), e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorNormalizeUsernameTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorNormalizeUsernameTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.fido;
+
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authenticator.fido.internal.FIDOAuthenticatorServiceComponent;
+import org.wso2.carbon.identity.application.authenticator.fido.util.FIDOUtil;
+import org.wso2.carbon.identity.application.authenticator.fido2.core.WebAuthnService;
+import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorServerException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link FIDOAuthenticator#normalizeAuthenticatedUser} passkey-username-case normalization
+ * (issue #7113). Exercises the case-sensitivity guard, the no-passkey (blank resolver result) path
+ * and the resolver server-error path.
+ */
+public class FIDOAuthenticatorNormalizeUsernameTest {
+
+    private static final String TENANT_DOMAIN = "carbon.super";
+    private static final int TENANT_ID = -1234;
+    private static final String USER_STORE_DOMAIN = "PRIMARY";
+    private static final String REQUEST_USERNAME = "Johndoe";   // case as supplied via authorize param.
+    private static final String STORED_USERNAME = "johndoe";    // case the passkey was enrolled under.
+
+    private FIDOAuthenticator fidoAuthenticator;
+
+    @Mock
+    private RealmService realmService;
+    @Mock
+    private TenantManager tenantManager;
+    @Mock
+    private UserRealm userRealm;
+    @Mock
+    private AbstractUserStoreManager userStoreManager;
+
+    private MockedStatic<IdentityUtil> identityUtilMock;
+    private MockedStatic<FIDOUtil> fidoUtilMock;
+    private MockedStatic<FIDOAuthenticatorServiceComponent> fidoAuthenticatorServiceComponentMock;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        fidoAuthenticator = FIDOAuthenticator.getInstance();
+        MockitoAnnotations.openMocks(this);
+
+        identityUtilMock = mockStatic(IdentityUtil.class);
+        fidoUtilMock = mockStatic(FIDOUtil.class);
+        fidoAuthenticatorServiceComponentMock = mockStatic(FIDOAuthenticatorServiceComponent.class);
+
+        fidoAuthenticatorServiceComponentMock.when(FIDOAuthenticatorServiceComponent::getRealmService)
+                .thenReturn(realmService);
+        when(realmService.getTenantManager()).thenReturn(tenantManager);
+        when(tenantManager.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
+        when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        // User exists in the primary store, so the secondary-store domain resolution loop is skipped.
+        when(userStoreManager.isExistingUser(anyString())).thenReturn(true);
+
+        // FIDOUtil.getUsernameWithoutDomain is a passthrough for non-domain-qualified usernames.
+        fidoUtilMock.when(() -> FIDOUtil.getUsernameWithoutDomain(anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        if (identityUtilMock != null) {
+            identityUtilMock.close();
+        }
+        if (fidoUtilMock != null) {
+            fidoUtilMock.close();
+        }
+        if (fidoAuthenticatorServiceComponentMock != null) {
+            fidoAuthenticatorServiceComponentMock.close();
+        }
+    }
+
+    private AuthenticationContext context() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setTenantDomain(TENANT_DOMAIN);
+        return context;
+    }
+
+    private AuthenticatedUser authenticatedUser(String username) {
+
+        AuthenticatedUser user = new AuthenticatedUser();
+        user.setUserName(username);
+        user.setUserStoreDomain(USER_STORE_DOMAIN);
+        user.setTenantDomain(TENANT_DOMAIN);
+        return user;
+    }
+
+    @Test(description = "Case-insensitive store + resolver returns canonical username -> username " +
+            "normalized to the stored case.")
+    public void testNormalizesUsernameWhenStoreCaseInsensitive() throws Exception {
+
+        identityUtilMock.when(() -> IdentityUtil.isUserStoreCaseSensitive(USER_STORE_DOMAIN, TENANT_ID))
+                .thenReturn(false);
+
+        try (MockedConstruction<WebAuthnService> ignored = Mockito.mockConstruction(WebAuthnService.class,
+                (mock, ctx) -> when(mock.resolveStoredUsername(REQUEST_USERNAME, TENANT_DOMAIN, USER_STORE_DOMAIN))
+                        .thenReturn(STORED_USERNAME))) {
+
+            AuthenticatedUser result = fidoAuthenticator.normalizeAuthenticatedUser(
+                    context(), authenticatedUser(REQUEST_USERNAME));
+
+            Assert.assertEquals(result.getUserName(), STORED_USERNAME,
+                    "Username should be normalized to the enrolled passkey's stored case.");
+        }
+    }
+
+    @Test(description = "Store is case-SENSITIVE -> guard blocks resolution, username unchanged.")
+    public void testDoesNotNormalizeWhenStoreCaseSensitive() throws Exception {
+
+        identityUtilMock.when(() -> IdentityUtil.isUserStoreCaseSensitive(USER_STORE_DOMAIN, TENANT_ID))
+                .thenReturn(true);
+
+        try (MockedConstruction<WebAuthnService> construction = Mockito.mockConstruction(WebAuthnService.class)) {
+
+            AuthenticatedUser result = fidoAuthenticator.normalizeAuthenticatedUser(
+                    context(), authenticatedUser(REQUEST_USERNAME));
+
+            Assert.assertEquals(result.getUserName(), REQUEST_USERNAME,
+                    "On a case-sensitive store the username must be preserved verbatim.");
+            Assert.assertTrue(construction.constructed().isEmpty(),
+                    "The passkey resolver must not be invoked on a case-sensitive store.");
+        }
+    }
+
+    @Test(description = "Case-insensitive store but resolver returns null (no enrolled passkey) -> " +
+            "username unchanged so genuine progressive enrollment still occurs.")
+    public void testDoesNotNormalizeWhenResolverReturnsNull() throws Exception {
+
+        identityUtilMock.when(() -> IdentityUtil.isUserStoreCaseSensitive(USER_STORE_DOMAIN, TENANT_ID))
+                .thenReturn(false);
+
+        try (MockedConstruction<WebAuthnService> ignored = Mockito.mockConstruction(WebAuthnService.class,
+                (mock, ctx) -> when(mock.resolveStoredUsername(REQUEST_USERNAME, TENANT_DOMAIN, USER_STORE_DOMAIN))
+                        .thenReturn(null))) {
+
+            AuthenticatedUser result = fidoAuthenticator.normalizeAuthenticatedUser(
+                    context(), authenticatedUser(REQUEST_USERNAME));
+
+            Assert.assertEquals(result.getUserName(), REQUEST_USERNAME,
+                    "With no enrolled passkey the request username must be preserved.");
+        }
+    }
+
+    @Test(description = "Case-insensitive store but resolver returns blank -> username unchanged.")
+    public void testDoesNotNormalizeWhenResolverReturnsBlank() throws Exception {
+
+        identityUtilMock.when(() -> IdentityUtil.isUserStoreCaseSensitive(USER_STORE_DOMAIN, TENANT_ID))
+                .thenReturn(false);
+
+        try (MockedConstruction<WebAuthnService> ignored = Mockito.mockConstruction(WebAuthnService.class,
+                (mock, ctx) -> when(mock.resolveStoredUsername(REQUEST_USERNAME, TENANT_DOMAIN, USER_STORE_DOMAIN))
+                        .thenReturn("   "))) {
+
+            AuthenticatedUser result = fidoAuthenticator.normalizeAuthenticatedUser(
+                    context(), authenticatedUser(REQUEST_USERNAME));
+
+            Assert.assertEquals(result.getUserName(), REQUEST_USERNAME,
+                    "A blank resolver result must not overwrite the request username.");
+        }
+    }
+
+    @Test(description = "Case-insensitive store but resolver hits a server error -> the flow fails " +
+            "instead of silently authenticating with the un-normalized username.",
+            expectedExceptions = AuthenticationFailedException.class)
+    public void testFailsWhenResolverThrowsServerException() throws Exception {
+
+        identityUtilMock.when(() -> IdentityUtil.isUserStoreCaseSensitive(USER_STORE_DOMAIN, TENANT_ID))
+                .thenReturn(false);
+
+        try (MockedConstruction<WebAuthnService> ignored = Mockito.mockConstruction(WebAuthnService.class,
+                (mock, ctx) -> when(mock.resolveStoredUsername(REQUEST_USERNAME, TENANT_DOMAIN, USER_STORE_DOMAIN))
+                        .thenThrow(new FIDO2AuthenticatorServerException("DB error", new RuntimeException("boom"))))) {
+
+            fidoAuthenticator.normalizeAuthenticatedUser(context(), authenticatedUser(REQUEST_USERNAME));
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/resources/testng.xml
@@ -23,6 +23,7 @@
     <test name="FIDO-Authenticator-Unit-Tests">
         <classes>
             <class name="org.wso2.carbon.identity.application.authenticator.fido.FIDOAuthenticatorTest" />
+            <class name="org.wso2.carbon.identity.application.authenticator.fido.FIDOAuthenticatorNormalizeUsernameTest" />
             <class name="org.wso2.carbon.identity.application.authenticator.fido.service.FIDOAdminServiceTest" />
             <class name="org.wso2.carbon.identity.application.authenticator.fido.u2f.U2FServiceTest" />
         </classes>

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnService.java
@@ -1768,6 +1768,27 @@ public class WebAuthnService {
         return fidoTrustedOrigins;
     }
 
+    /**
+     * Resolve the username under which a passkey is stored for the given user, matching the request username
+     * case-insensitively. Returns the stored (canonical) username, or null if the user has no registered passkey.
+     * Used to normalize a case-differing request username to the enrolled passkey's username.
+     *
+     * @param username        Request username (domain free).
+     * @param tenantDomain    Tenant domain.
+     * @param userStoreDomain User store domain.
+     * @return The stored passkey username, or null if none is registered.
+     * @throws FIDO2AuthenticatorServerException
+     */
+    public String resolveStoredUsername(String username, String tenantDomain, String userStoreDomain)
+            throws FIDO2AuthenticatorServerException {
+
+        User user = new User();
+        user.setUserName(username);
+        user.setTenantDomain(tenantDomain);
+        user.setUserStoreDomain(userStoreDomain);
+        return userStorage.getStoredUsernameIgnoreCase(user);
+    }
+
     public boolean isFidoKeyRegistered(String username) throws AuthenticationFailedException {
 
         try {

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/dao/FIDO2DeviceStoreDAO.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/dao/FIDO2DeviceStoreDAO.java
@@ -426,6 +426,39 @@ public class FIDO2DeviceStoreDAO implements CredentialRepository {
     }
 
     /**
+     * Resolve the username under which a passkey is stored for the given user, matching case-insensitively.
+     * Returns the stored (canonical) USER_NAME so a case-differing request username still maps to the
+     * enrolled passkey. Returns null when no passkey exists for the user.
+     *
+     * @param user User (tenant domain, user store domain and username).
+     * @return The stored passkey username, or null if none is registered.
+     * @throws FIDO2AuthenticatorServerException
+     */
+    public String getStoredUsernameIgnoreCase(User user) throws FIDO2AuthenticatorServerException {
+
+        Connection connection = IdentityDatabaseUtil.getDBConnection();
+        PreparedStatement preparedStatement = null;
+        ResultSet resultSet = null;
+        try {
+            preparedStatement = connection.prepareStatement(FIDO2AuthenticatorConstants.SQLQueries
+                    .GET_USERNAME_BY_CASE_INSENSITIVE_USERNAME);
+            preparedStatement.setInt(1, IdentityTenantUtil.getTenantId(user.getTenantDomain()));
+            preparedStatement.setString(2, user.getUserStoreDomain());
+            preparedStatement.setString(3, user.getUserName());
+            resultSet = preparedStatement.executeQuery();
+            if (resultSet.next()) {
+                return resultSet.getString(FIDO2AuthenticatorConstants.USERNAME);
+            }
+            return null;
+        } catch (SQLException e) {
+            throw new FIDO2AuthenticatorServerException("Error while resolving stored passkey username for user: "
+                    + user, e);
+        } finally {
+            IdentityDatabaseUtil.closeAllConnections(connection, resultSet, preparedStatement);
+        }
+    }
+
+    /**
      * Retrieve FIDO2 registration details.
      *
      * @param user User.

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/dao/FIDO2DeviceStoreDAO.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/dao/FIDO2DeviceStoreDAO.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.application.authenticator.fido2.dto.FIDO2Credent
 import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorServerException;
 import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2AuthenticatorConstants;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -451,8 +452,10 @@ public class FIDO2DeviceStoreDAO implements CredentialRepository {
             }
             return null;
         } catch (SQLException e) {
+            String maskedUsername = LoggerUtils.isLogMaskingEnable
+                    ? LoggerUtils.getMaskedContent(user.getUserName()) : user.getUserName();
             throw new FIDO2AuthenticatorServerException("Error while resolving stored passkey username for user: "
-                    + user, e);
+                    + maskedUsername, e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, resultSet, preparedStatement);
         }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/main/java/org/wso2/carbon/identity/application/authenticator/fido2/util/FIDO2AuthenticatorConstants.java
@@ -97,6 +97,9 @@ public class FIDO2AuthenticatorConstants {
         public static final String GET_DEVICE_REGISTRATION_BY_USERNAME = "SELECT * FROM FIDO2_DEVICE_STORE " +
                 "WHERE TENANT_ID = ? AND DOMAIN_NAME = ? AND USER_NAME = ?";
 
+        public static final String GET_USERNAME_BY_CASE_INSENSITIVE_USERNAME = "SELECT USER_NAME FROM " +
+                "FIDO2_DEVICE_STORE WHERE TENANT_ID = ? AND DOMAIN_NAME = ? AND LOWER(USER_NAME) = LOWER(?)";
+
         public static final String GET_DEVICE_REGISTRATION_BY_USERNAME_AND_ID = "SELECT * FROM FIDO2_DEVICE_STORE " +
                 "WHERE TENANT_ID = ? AND DOMAIN_NAME = ? AND USER_NAME = ? AND CREDENTIAL_ID = ?";
 

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnServiceTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/core/WebAuthnServiceTest.java
@@ -48,6 +48,7 @@ import com.yubico.webauthn.data.ResidentKeyRequirement;
 import com.yubico.webauthn.data.UserIdentity;
 import com.yubico.webauthn.data.exception.Base64UrlException;
 import com.yubico.webauthn.exception.AssertionFailedException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
@@ -1046,6 +1047,49 @@ public class WebAuthnServiceTest {
                     finishRegistrationResponseString, TENANT_QUALIFIED_USERNAME);
             Assert.assertNotNull(result);
         }
+    }
+
+    /**
+     * {@code userStorage} is a private static final field bound to the DAO returned by the first
+     * {@code FIDO2DeviceStoreDAO.getInstance()} call that loaded the class; read it reflectively so the test
+     * stubs/verifies against the actual delegate regardless of which mock instance it resolved to.
+     */
+    private FIDO2DeviceStoreDAO boundUserStorage() throws Exception {
+
+        java.lang.reflect.Field field = WebAuthnService.class.getDeclaredField("userStorage");
+        field.setAccessible(true);
+        return (FIDO2DeviceStoreDAO) field.get(null);
+    }
+
+    @Test(description = "resolveStoredUsername (#7113): delegates to the DAO with a User built from the supplied " +
+            "username/tenant/store and returns the stored canonical username.", priority = 25)
+    public void testResolveStoredUsername() throws Exception {
+
+        FIDO2DeviceStoreDAO boundStorage = boundUserStorage();
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        when(boundStorage.getStoredUsernameIgnoreCase(any(User.class))).thenReturn(USERNAME);
+
+        String resolved = webAuthnService.resolveStoredUsername("Admin", TENANT_DOMAIN, USER_STORE_DOMAIN);
+
+        Assert.assertEquals(resolved, USERNAME, "Should return the DAO-resolved canonical username.");
+        Mockito.verify(boundStorage, Mockito.atLeastOnce()).getStoredUsernameIgnoreCase(userCaptor.capture());
+        User passed = userCaptor.getValue();
+        Assert.assertEquals(passed.getUserName(), "Admin", "Request username must be forwarded verbatim.");
+        Assert.assertEquals(passed.getTenantDomain(), TENANT_DOMAIN);
+        Assert.assertEquals(passed.getUserStoreDomain(), USER_STORE_DOMAIN);
+    }
+
+    @Test(description = "resolveStoredUsername (#7113): returns null (no enrolled passkey) when the DAO returns null.",
+            priority = 26)
+    public void testResolveStoredUsernameReturnsNullWhenNoPasskey() throws Exception {
+
+        // The static-field DAO mock is shared across tests, so assert on the returned value (a null DAO
+        // result must surface as a null resolution) rather than a count-sensitive interaction check.
+        when(boundUserStorage().getStoredUsernameIgnoreCase(any(User.class))).thenReturn(null);
+
+        String resolved = webAuthnService.resolveStoredUsername("Admin", TENANT_DOMAIN, USER_STORE_DOMAIN);
+
+        Assert.assertNull(resolved, "Should return null when the user has no registered passkey.");
     }
 
     private void mockCarbonContext() {

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/dao/FIDO2DeviceStoreDAOTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/java/org/wso2/carbon/identity/application/authenticator/fido2/dao/FIDO2DeviceStoreDAOTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.fido2.dao;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authenticator.fido2.exception.FIDO2AuthenticatorServerException;
+import org.wso2.carbon.identity.application.authenticator.fido2.util.FIDO2AuthenticatorConstants;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link FIDO2DeviceStoreDAO#getStoredUsernameIgnoreCase} (issue #7113).
+ *
+ * <p>The FIDO2 test module has no H2 / data-source harness, so following the established Mockito-inline
+ * DAO-testing style in this module these tests drive a mocked JDBC connection and assert: the
+ * case-insensitive SQL is issued, the three parameters (tenant id, domain, request username) are bound
+ * verbatim, and the row/no-row return contract. The case-insensitive matching itself is delegated to SQL
+ * {@code LOWER(USER_NAME) = LOWER(?)}, which is asserted by pinning the exact query constant.</p>
+ */
+public class FIDO2DeviceStoreDAOTest {
+
+    private static final String TENANT_DOMAIN = "carbon.super";
+    private static final int TENANT_ID = -1234;
+    private static final String DOMAIN_NAME = "PRIMARY";
+    private static final String STORED_USERNAME = "johndoe";
+
+    private FIDO2DeviceStoreDAO dao;
+
+    @Mock
+    private Connection connection;
+    @Mock
+    private PreparedStatement preparedStatement;
+    @Mock
+    private ResultSet resultSet;
+
+    private MockedStatic<IdentityDatabaseUtil> identityDatabaseUtilMock;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtilMock;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        dao = new FIDO2DeviceStoreDAO();
+        MockitoAnnotations.openMocks(this);
+
+        identityDatabaseUtilMock = mockStatic(IdentityDatabaseUtil.class);
+        identityTenantUtilMock = mockStatic(IdentityTenantUtil.class);
+
+        identityDatabaseUtilMock.when(IdentityDatabaseUtil::getDBConnection).thenReturn(connection);
+        identityTenantUtilMock.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
+        when(connection.prepareStatement(FIDO2AuthenticatorConstants.SQLQueries
+                .GET_USERNAME_BY_CASE_INSENSITIVE_USERNAME)).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        if (identityDatabaseUtilMock != null) {
+            identityDatabaseUtilMock.close();
+        }
+        if (identityTenantUtilMock != null) {
+            identityTenantUtilMock.close();
+        }
+    }
+
+    private User user(String username) {
+
+        User user = new User();
+        user.setUserName(username);
+        user.setTenantDomain(TENANT_DOMAIN);
+        user.setUserStoreDomain(DOMAIN_NAME);
+        return user;
+    }
+
+    @Test(description = "Enrolled 'johndoe': a differing-case lookup ('Johndoe') resolves to the stored 'johndoe' " +
+            "and binds tenant id, domain and the request username to the case-insensitive query.")
+    public void testReturnsStoredUsernameForCaseDifferingLookup() throws Exception {
+
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(FIDO2AuthenticatorConstants.USERNAME)).thenReturn(STORED_USERNAME);
+
+        String resolved = dao.getStoredUsernameIgnoreCase(user("Johndoe"));
+
+        Assert.assertEquals(resolved, STORED_USERNAME,
+                "Case-insensitive lookup must return the stored (enrolled) username case.");
+        verify(connection).prepareStatement(FIDO2AuthenticatorConstants.SQLQueries
+                .GET_USERNAME_BY_CASE_INSENSITIVE_USERNAME);
+        verify(preparedStatement).setInt(1, TENANT_ID);
+        verify(preparedStatement).setString(2, DOMAIN_NAME);
+        verify(preparedStatement).setString(3, "Johndoe");
+    }
+
+    @Test(description = "Enrolled 'johndoe': an all-caps lookup ('JOHNDOE') resolves to the stored 'johndoe'.")
+    public void testReturnsStoredUsernameForUpperCaseLookup() throws Exception {
+
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(FIDO2AuthenticatorConstants.USERNAME)).thenReturn(STORED_USERNAME);
+
+        String resolved = dao.getStoredUsernameIgnoreCase(user("JOHNDOE"));
+
+        Assert.assertEquals(resolved, STORED_USERNAME);
+        verify(preparedStatement).setString(3, "JOHNDOE");
+    }
+
+    @Test(description = "Exact-case lookup ('johndoe') returns the stored 'johndoe'.")
+    public void testReturnsStoredUsernameForExactLookup() throws Exception {
+
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(FIDO2AuthenticatorConstants.USERNAME)).thenReturn(STORED_USERNAME);
+
+        String resolved = dao.getStoredUsernameIgnoreCase(user("johndoe"));
+
+        Assert.assertEquals(resolved, STORED_USERNAME);
+    }
+
+    @Test(description = "A user with NO registered passkey (no matching row) returns null.")
+    public void testReturnsNullWhenNoPasskeyRegistered() throws Exception {
+
+        when(resultSet.next()).thenReturn(false);
+
+        String resolved = dao.getStoredUsernameIgnoreCase(user("Nobody"));
+
+        Assert.assertNull(resolved, "A user with no enrolled passkey must resolve to null.");
+    }
+
+    @Test(description = "Domain isolation: the lookup binds the requested DOMAIN_NAME, so a row stored under a " +
+            "different domain (filtered out by SQL, no row returned) yields null.")
+    public void testDomainIsolationReturnsNull() throws Exception {
+
+        // Row exists under DOMAIN 'X' but the query is scoped to 'PRIMARY' (DOMAIN_NAME = ?) so no row matches.
+        when(resultSet.next()).thenReturn(false);
+
+        String resolved = dao.getStoredUsernameIgnoreCase(user("johndoe"));
+
+        Assert.assertNull(resolved);
+        verify(preparedStatement).setString(2, DOMAIN_NAME);
+    }
+
+    @Test(description = "A SQLException from the query is wrapped in a FIDO2AuthenticatorServerException.",
+            expectedExceptions = {FIDO2AuthenticatorServerException.class})
+    public void testWrapsSqlException() throws Exception {
+
+        when(preparedStatement.executeQuery()).thenThrow(new SQLException("boom"));
+
+        dao.getStoredUsernameIgnoreCase(user("johndoe"));
+    }
+
+    @Test(description = "Connections are always closed via IdentityDatabaseUtil.closeAllConnections.")
+    public void testClosesConnections() throws Exception {
+
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(FIDO2AuthenticatorConstants.USERNAME)).thenReturn(STORED_USERNAME);
+
+        dao.getStoredUsernameIgnoreCase(user("johndoe"));
+
+        identityDatabaseUtilMock.verify(() -> IdentityDatabaseUtil.closeAllConnections(
+                eq(connection), any(ResultSet.class), any(PreparedStatement.class)));
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido2/src/test/resources/testng.xml
@@ -22,6 +22,7 @@
     <test name="FIDO-Authenticator-Unit-Tests">
         <classes>
             <class name="org.wso2.carbon.identity.application.authenticator.fido2.core.WebAuthnServiceTest"/>
+            <class name="org.wso2.carbon.identity.application.authenticator.fido2.dao.FIDO2DeviceStoreDAOTest"/>
             <class name="org.wso2.carbon.identity.application.authenticator.fido2.executor.FIDO2ExecutorTest"/>
         </classes>
     </test>


### PR DESCRIPTION
### Root cause and fix
- When the OAuth `username`/`login_hint` authorize parameter bypasses the Identifier First step, the verbatim parameter value becomes the authentication subject without user-store canonical-case resolution. The FIDO2 device-store lookup is a case-sensitive `USER_NAME = ?` equality, so a user enrolled as `johndoe` is not matched when `Johndoe`/`JOHNDOE` is supplied — the enrolled user is wrongly prompted to re-enroll.
- Fix: on a **case-insensitive** user store, `FIDOAuthenticator.normalizeAuthenticatedUser` now resolves the request username to the case the passkey was enrolled under, read directly from `FIDO2_DEVICE_STORE` via a single case-insensitive query (`LOWER(USER_NAME) = LOWER(?)`, ANSI-portable). Applied at the single chokepoint before the downstream case-sensitive lookups, and guarded by `!IdentityUtil.isUserStoreCaseSensitive(...)` so case-sensitive stores are unaffected.
- New plumbing: `FIDO2DeviceStoreDAO.getStoredUsernameIgnoreCase(User)` → `WebAuthnService.resolveStoredUsername(...)` → `FIDOAuthenticator.resolveStoredPasskeyUsername(...)`. A resolver server error fails the flow rather than silently authenticating with the un-normalized username.

### Tests
- `FIDO2DeviceStoreDAOTest` (new), `FIDOAuthenticatorNormalizeUsernameTest` (new), and two `WebAuthnServiceTest` delegate tests — written in the module's Mockito-inline style. `mvn clean install` green on both components.

### Source fix
- Support-branch fix (`wso2-support/identity-local-auth-fido`): https://github.com/wso2-support/identity-local-auth-fido/pull/98 + knob removal https://github.com/wso2-support/identity-local-auth-fido/pull/99. This master port applies the fix unconditionally (no config knob), matching the final support state.

### Tracking issue
- Public: https://github.com/wso2/product-is/issues/27735

---
This PR was generated by Claude and should be reviewed carefully before merging.