### PR TITLE
Honour BlockedUserStoreDomains when resolving the FIDO user store domain

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -126,12 +126,6 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
     private static final String AUTHENTICATOR_MESSAGE = "authenticatorMessage";
     public static final String IDF_AUTHENTICATOR = "IdentifierExecutor";
 
-    /**
-     * Context property set by {@link #normalizeAuthenticatedUser} when the user exists only in user store domains
-     * that are blocked for FIDO authentication. The resolved user store domain cannot carry this information, since
-     * an unresolved user is deliberately left with the last walked domain to keep the flow indistinguishable from a
-     * user who has no enrolled passkeys.
-     */
     private static final String IS_USER_STORE_DOMAIN_BLOCKED = "isUserStoreDomainBlocked";
 
     @Override
@@ -182,18 +176,12 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
 
         if (authenticatedUser != null) {
 
-            // The domain check covers the flows where the user store domain was not resolved by
-            // normalizeAuthenticatedUser, such as a domain qualified username or a first step that is not the
-            // Identifier First authenticator. The context property covers the users who could only be found in a
-            // blocked domain, since those are not left with a blocked user store domain.
             boolean isResolvedDomainBlocked =
                     getBlockedUserStoreDomainsList().contains(authenticatedUser.getUserStoreDomain());
             boolean existsOnlyInBlockedDomains =
                     Boolean.TRUE.equals(context.getProperty(IS_USER_STORE_DOMAIN_BLOCKED));
 
             if (isResolvedDomainBlocked || existsOnlyInBlockedDomains) {
-                // An unresolved user carries the last walked user store domain rather than a blocked one, so the
-                // resolved domain must not be reported as the blocked one in that case.
                 String blockReason = isResolvedDomainBlocked
                         ? "The user store domain: " + authenticatedUser.getUserStoreDomain() +
                                 " is blocked for FIDO authentication."
@@ -1445,8 +1433,6 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
 
             final boolean isDomainQualified = username.contains(CarbonConstants.DOMAIN_SEPARATOR);
             final boolean isPrimaryDomainBlocked = blockedUserStoreDomainsList.contains(userStoreManagerDomain);
-            // isExistingUser routes a domain qualified username to the store named in the username, so it only
-            // reports on the primary store when the username carries no domain.
             final boolean existsInPrimaryDomain = !isDomainQualified && userStoreManager.isExistingUser(username);
 
             boolean isUserResolved = false;
@@ -1465,8 +1451,6 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                                 isUserResolved = true;
                                 break;
                             }
-                            // The user exists here but the domain is blocked. Keep walking in case a usable store
-                            // holds the same username, and record that this username is not unknown.
                             existsInBlockedDomain = true;
                         }
                     }
@@ -1474,9 +1458,6 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                 }
             }
 
-            // An unresolved user keeps the last walked user store domain so that the remaining flow is identical to
-            // that of a user without enrolled passkeys. Only a user who genuinely exists in a blocked domain is
-            // flagged as blocked, so an unknown username is never distinguishable from a user with no passkeys.
             context.setProperty(IS_USER_STORE_DOMAIN_BLOCKED, existsInBlockedDomain && !isUserResolved);
 
             // On a case-insensitive store, resolve the username to the case under which the passkey was

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -93,6 +93,8 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.BLOCKED_USERSTORE_DOMAINS_LIST;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.BLOCKED_USERSTORE_DOMAINS_SEPARATOR;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.AUTHENTICATOR_FIDO;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.CHALLENGE_DATA;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.CHALLENGE_RESPONSE;
@@ -111,7 +113,6 @@ import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOA
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.TOKEN_RESPONSE;
 import static org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants.USER_NAME;
 import static org.wso2.carbon.identity.application.authenticator.fido2.util.FIDOUtil.writeJson;
-import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME;
 
 /**
  * FIDO U2F Specification based authenticator.
@@ -124,6 +125,14 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
     private static FIDOAuthenticator instance = new FIDOAuthenticator();
     private static final String AUTHENTICATOR_MESSAGE = "authenticatorMessage";
     public static final String IDF_AUTHENTICATOR = "IdentifierExecutor";
+
+    /**
+     * Context property set by {@link #normalizeAuthenticatedUser} when the user exists only in user store domains
+     * that are blocked for FIDO authentication. The resolved user store domain cannot carry this information, since
+     * an unresolved user is deliberately left with the last walked domain to keep the flow indistinguishable from a
+     * user who has no enrolled passkeys.
+     */
+    private static final String IS_USER_STORE_DOMAIN_BLOCKED = "isUserStoreDomainBlocked";
 
     @Override
     public AuthenticatorFlowStatus process(HttpServletRequest request, HttpServletResponse response,
@@ -172,6 +181,40 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         AuthenticatedUser authenticatedUser = getAuthenticatedUser(context);
 
         if (authenticatedUser != null) {
+
+            // The domain check covers the flows where the user store domain was not resolved by
+            // normalizeAuthenticatedUser, such as a domain qualified username or a first step that is not the
+            // Identifier First authenticator. The context property covers the users who could only be found in a
+            // blocked domain, since those are not left with a blocked user store domain.
+            boolean isResolvedDomainBlocked =
+                    getBlockedUserStoreDomainsList().contains(authenticatedUser.getUserStoreDomain());
+            boolean existsOnlyInBlockedDomains =
+                    Boolean.TRUE.equals(context.getProperty(IS_USER_STORE_DOMAIN_BLOCKED));
+
+            if (isResolvedDomainBlocked || existsOnlyInBlockedDomains) {
+                // An unresolved user carries the last walked user store domain rather than a blocked one, so the
+                // resolved domain must not be reported as the blocked one in that case.
+                String blockReason = isResolvedDomainBlocked
+                        ? "The user store domain: " + authenticatedUser.getUserStoreDomain() +
+                                " is blocked for FIDO authentication."
+                        : "The user could only be found in user store domains that are blocked for FIDO " +
+                                "authentication.";
+                if (log.isDebugEnabled()) {
+                    log.debug(blockReason);
+                }
+                if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                    DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                            FIDO_AUTH_SERVICE, VALIDATE_FIDO_REQUEST);
+                    diagnosticLogBuilder.resultMessage(blockReason)
+                            .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                            .resultStatus(DiagnosticLog.ResultStatus.FAILED)
+                            .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                            .inputParams(getApplicationDetails(context));
+                    LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+                }
+                redirectToPasskeysExistenceStatusPage(response, context, false);
+                return AuthenticatorFlowStatus.INCOMPLETE;
+            }
 
             // We need to identify the username that the server is using to identify the user. This is needed to handle
             // federated scenarios, since for federated users, the username in the authentication context is not same
@@ -1394,26 +1437,47 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                         String.format("Cannot find the user realm for the given tenant: %s", tenantId));
             }
 
+            final List<String> blockedUserStoreDomainsList = getBlockedUserStoreDomainsList();
+
             final AbstractUserStoreManager userStoreManager =
                     (AbstractUserStoreManager) userRealm.getUserStoreManager();
+            final String userStoreManagerDomain = getUserStoreManagerDomainName(userStoreManager);
 
-            if (!userStoreManager.isExistingUser(username) && !username.contains(CarbonConstants.DOMAIN_SEPARATOR)) {
+            final boolean isDomainQualified = username.contains(CarbonConstants.DOMAIN_SEPARATOR);
+            final boolean isPrimaryDomainBlocked = blockedUserStoreDomainsList.contains(userStoreManagerDomain);
+            // isExistingUser routes a domain qualified username to the store named in the username, so it only
+            // reports on the primary store when the username carries no domain.
+            final boolean existsInPrimaryDomain = !isDomainQualified && userStoreManager.isExistingUser(username);
+
+            boolean isUserResolved = false;
+            boolean existsInBlockedDomain = isPrimaryDomainBlocked && existsInPrimaryDomain;
+
+            if ((isPrimaryDomainBlocked || !existsInPrimaryDomain) && !isDomainQualified) {
                 UserStoreManager secondary = userStoreManager.getSecondaryUserStoreManager();
                 while (secondary != null) {
-                    final String domain = secondary.getRealmConfiguration()
-                            .getUserStoreProperties()
-                            .get(PROPERTY_DOMAIN_NAME);
+                    userStoreDomain = getUserStoreManagerDomainName(secondary);
 
-                    if (StringUtils.isNotBlank(domain)) {
-                        final String domainQualifiedUsername = UserCoreUtil.addDomainToName(username, domain);
+                    if (StringUtils.isNotBlank(userStoreDomain)) {
+                        final String domainQualifiedUsername =
+                                UserCoreUtil.addDomainToName(username, userStoreDomain);
                         if (userStoreManager.isExistingUser(domainQualifiedUsername)) {
-                            userStoreDomain = domain;
-                            break;
+                            if (!blockedUserStoreDomainsList.contains(userStoreDomain)) {
+                                isUserResolved = true;
+                                break;
+                            }
+                            // The user exists here but the domain is blocked. Keep walking in case a usable store
+                            // holds the same username, and record that this username is not unknown.
+                            existsInBlockedDomain = true;
                         }
                     }
                     secondary = secondary.getSecondaryUserStoreManager();
                 }
             }
+
+            // An unresolved user keeps the last walked user store domain so that the remaining flow is identical to
+            // that of a user without enrolled passkeys. Only a user who genuinely exists in a blocked domain is
+            // flagged as blocked, so an unknown username is never distinguishable from a user with no passkeys.
+            context.setProperty(IS_USER_STORE_DOMAIN_BLOCKED, existsInBlockedDomain && !isUserResolved);
 
             // On a case-insensitive store, resolve the username to the case under which the passkey was
             // enrolled so a case-differing authorize `username` param (which bypasses Identifier First)
@@ -1472,5 +1536,40 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         } else {
             return user;
         }
+    }
+
+    /**
+     * Resolves the domain name of the given user store. {@link UserCoreUtil#getDomainName} dereferences the realm
+     * configuration, so the absence of one is handled here and reported as an unknown domain.
+     *
+     * @param userStoreManager The user store manager to read the domain name from.
+     * @return The upper cased domain name, or null when it cannot be determined.
+     */
+    private String getUserStoreManagerDomainName(UserStoreManager userStoreManager) {
+
+        if (userStoreManager == null || userStoreManager.getRealmConfiguration() == null) {
+            return null;
+        }
+        return UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
+    }
+
+    /**
+     * Reads the user store domains that are blocked for FIDO authentication from the authenticator configuration.
+     * Entries are trimmed and upper cased, since they are compared against domain names returned by
+     * {@link UserCoreUtil#getDomainName}, which upper cases them.
+     *
+     * @return The blocked user store domain names, empty when the configuration is not set.
+     */
+    private List<String> getBlockedUserStoreDomainsList() {
+
+        List<String> blockedUserStoreDomainsList = new ArrayList<>();
+        String blockedUserStoreDomains =
+                getAuthenticatorConfig().getParameterMap().get(BLOCKED_USERSTORE_DOMAINS_LIST);
+        if (StringUtils.isNotBlank(blockedUserStoreDomains)) {
+            for (String domain : StringUtils.split(blockedUserStoreDomains, BLOCKED_USERSTORE_DOMAINS_SEPARATOR)) {
+                blockedUserStoreDomainsList.add(domain.trim().toUpperCase());
+            }
+        }
+        return blockedUserStoreDomainsList;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorBlockedUserStoreDomainTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorBlockedUserStoreDomainTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.fido;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authenticator.fido.internal.FIDOAuthenticatorServiceComponent;
+import org.wso2.carbon.identity.application.authenticator.fido.util.FIDOAuthenticatorConstants;
+import org.wso2.carbon.identity.application.authenticator.fido.util.FIDOUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.BLOCKED_USERSTORE_DOMAINS_LIST;
+
+/**
+ * Tests for the {@code BlockedUserStoreDomains} handling in {@link FIDOAuthenticator#normalizeAuthenticatedUser}
+ * (issue #28228).
+ * <p>
+ * Two behaviours are asserted. A user whose username also exists in a blocked domain must still resolve to a usable
+ * domain, and a user who can only be found in a blocked domain must be flagged so the blocked handling in
+ * {@code process} is not skipped. An unknown username must never be flagged, otherwise it becomes distinguishable
+ * from a user who simply has no enrolled passkeys.
+ * <p>
+ * The store topology used throughout is PRIMARY -> SEC1 -> SEC2.
+ */
+public class FIDOAuthenticatorBlockedUserStoreDomainTest {
+
+    private static final String TENANT_DOMAIN = "carbon.super";
+    private static final int TENANT_ID = -1234;
+
+    private static final String PRIMARY_DOMAIN = "PRIMARY";
+    private static final String SECONDARY_DOMAIN_ONE = "SEC1";
+    private static final String SECONDARY_DOMAIN_TWO = "SEC2";
+
+    private static final String USERNAME = "alice";
+    private static final String USERNAME_IN_SECONDARY_ONE = "SEC1/alice";
+    private static final String USERNAME_IN_SECONDARY_TWO = "SEC2/alice";
+
+    private static final String IS_USER_STORE_DOMAIN_BLOCKED = "isUserStoreDomainBlocked";
+
+    private FIDOAuthenticator fidoAuthenticator;
+
+    @Mock
+    private RealmService realmService;
+    @Mock
+    private TenantManager tenantManager;
+    @Mock
+    private UserRealm userRealm;
+    @Mock
+    private AbstractUserStoreManager primaryUserStoreManager;
+    @Mock
+    private UserStoreManager secondaryUserStoreManagerOne;
+    @Mock
+    private UserStoreManager secondaryUserStoreManagerTwo;
+    @Mock
+    private FileBasedConfigurationBuilder fileBasedConfigurationBuilder;
+
+    private MockedStatic<IdentityUtil> identityUtilMock;
+    private MockedStatic<FIDOUtil> fidoUtilMock;
+    private MockedStatic<FIDOAuthenticatorServiceComponent> fidoAuthenticatorServiceComponentMock;
+    private MockedStatic<FileBasedConfigurationBuilder> fileBasedConfigurationBuilderMock;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        fidoAuthenticator = FIDOAuthenticator.getInstance();
+        MockitoAnnotations.openMocks(this);
+
+        identityUtilMock = mockStatic(IdentityUtil.class);
+        fidoUtilMock = mockStatic(FIDOUtil.class);
+        fidoAuthenticatorServiceComponentMock = mockStatic(FIDOAuthenticatorServiceComponent.class);
+        fileBasedConfigurationBuilderMock = mockStatic(FileBasedConfigurationBuilder.class);
+
+        fidoAuthenticatorServiceComponentMock.when(FIDOAuthenticatorServiceComponent::getRealmService)
+                .thenReturn(realmService);
+        when(realmService.getTenantManager()).thenReturn(tenantManager);
+        when(tenantManager.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
+        when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(primaryUserStoreManager);
+
+        when(primaryUserStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration(PRIMARY_DOMAIN));
+        when(secondaryUserStoreManagerOne.getRealmConfiguration())
+                .thenReturn(realmConfiguration(SECONDARY_DOMAIN_ONE));
+        when(secondaryUserStoreManagerTwo.getRealmConfiguration())
+                .thenReturn(realmConfiguration(SECONDARY_DOMAIN_TWO));
+
+        when(primaryUserStoreManager.getSecondaryUserStoreManager()).thenReturn(secondaryUserStoreManagerOne);
+        when(secondaryUserStoreManagerOne.getSecondaryUserStoreManager()).thenReturn(secondaryUserStoreManagerTwo);
+        when(secondaryUserStoreManagerTwo.getSecondaryUserStoreManager()).thenReturn(null);
+
+        // The user exists nowhere unless a test says otherwise. Every existence check is routed through the primary
+        // store manager, which is how the authenticator resolves domain qualified usernames.
+        when(primaryUserStoreManager.isExistingUser(anyString())).thenReturn(false);
+
+        // Keep the case normalization block inert. It is covered by FIDOAuthenticatorNormalizeUsernameTest.
+        identityUtilMock.when(() -> IdentityUtil.isUserStoreCaseSensitive(anyString(), anyInt())).thenReturn(true);
+
+        fidoUtilMock.when(() -> FIDOUtil.getUsernameWithoutDomain(anyString()))
+                .thenAnswer(invocation -> {
+                    String name = invocation.getArgument(0);
+                    int separatorIndex = name.indexOf('/');
+                    return separatorIndex < 0 ? name : name.substring(separatorIndex + 1);
+                });
+
+        fileBasedConfigurationBuilderMock.when(FileBasedConfigurationBuilder::getInstance)
+                .thenReturn(fileBasedConfigurationBuilder);
+        givenBlockedUserStoreDomains(null);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        if (identityUtilMock != null) {
+            identityUtilMock.close();
+        }
+        if (fidoUtilMock != null) {
+            fidoUtilMock.close();
+        }
+        if (fidoAuthenticatorServiceComponentMock != null) {
+            fidoAuthenticatorServiceComponentMock.close();
+        }
+        if (fileBasedConfigurationBuilderMock != null) {
+            fileBasedConfigurationBuilderMock.close();
+        }
+    }
+
+    @Test(description = "Username exists in the blocked primary store and in a usable secondary store -> resolves " +
+            "to the secondary store so the enrolled passkey is found. This is the reported bug.")
+    public void testResolvesToSecondaryWhenPrimaryDomainIsBlocked() throws Exception {
+
+        givenBlockedUserStoreDomains(PRIMARY_DOMAIN);
+        givenExistingUsers(USERNAME, USERNAME_IN_SECONDARY_ONE);
+
+        AuthenticationContext context = context();
+        AuthenticatedUser result = fidoAuthenticator.normalizeAuthenticatedUser(context, authenticatedUser());
+
+        Assert.assertEquals(result.getUserStoreDomain(), SECONDARY_DOMAIN_ONE,
+                "The user must resolve to the secondary store that holds the passkey, not the blocked primary.");
+        Assert.assertFalse(isUserStoreDomainBlocked(context),
+                "A user resolved to a usable domain must not be flagged as blocked.");
+    }
+
+    @Test(description = "Username exists only in the blocked primary store -> flagged as blocked so progressive " +
+            "enrollment does not run against a domain the user is absent from.")
+    public void testFlagsBlockedWhenUserOnlyExistsInBlockedPrimaryDomain() throws Exception {
+
+        givenBlockedUserStoreDomains(PRIMARY_DOMAIN);
+        givenExistingUsers(USERNAME);
+
+        AuthenticationContext context = context();
+        fidoAuthenticator.normalizeAuthenticatedUser(context, authenticatedUser());
+
+        Assert.assertTrue(isUserStoreDomainBlocked(context),
+                "A user who exists only in a blocked domain must be flagged as blocked.");
+    }
+
+    @Test(description = "Username exists only in a blocked secondary store -> flagged as blocked. Blocking a " +
+            "secondary store must behave the same as blocking the primary store.")
+    public void testFlagsBlockedWhenUserOnlyExistsInBlockedSecondaryDomain() throws Exception {
+
+        givenBlockedUserStoreDomains(SECONDARY_DOMAIN_ONE);
+        givenExistingUsers(USERNAME_IN_SECONDARY_ONE);
+
+        AuthenticationContext context = context();
+        fidoAuthenticator.normalizeAuthenticatedUser(context, authenticatedUser());
+
+        Assert.assertTrue(isUserStoreDomainBlocked(context),
+                "A user who exists only in a blocked secondary domain must be flagged as blocked.");
+    }
+
+    @Test(description = "Username exists in a blocked secondary store and in a usable one -> the walk continues " +
+            "past the blocked store and resolves to the usable one.")
+    public void testResolvesToUsableSecondaryWhenAnotherSecondaryDomainIsBlocked() throws Exception {
+
+        givenBlockedUserStoreDomains(SECONDARY_DOMAIN_ONE);
+        givenExistingUsers(USERNAME_IN_SECONDARY_ONE, USERNAME_IN_SECONDARY_TWO);
+
+        AuthenticationContext context = context();
+        AuthenticatedUser result = fidoAuthenticator.normalizeAuthenticatedUser(context, authenticatedUser());
+
+        Assert.assertEquals(result.getUserStoreDomain(), SECONDARY_DOMAIN_TWO,
+                "A blocked secondary store must not stop the walk at the first match.");
+        Assert.assertFalse(isUserStoreDomainBlocked(context),
+                "A user resolved to a usable domain must not be flagged as blocked.");
+    }
+
+    @Test(description = "Unknown username with a blocked domain configured -> not flagged, and the last walked " +
+            "domain is still assigned, so the flow stays indistinguishable from a user with no passkeys.")
+    public void testDoesNotFlagUnknownUsername() throws Exception {
+
+        givenBlockedUserStoreDomains(PRIMARY_DOMAIN);
+
+        AuthenticationContext context = context();
+        AuthenticatedUser result = fidoAuthenticator.normalizeAuthenticatedUser(context, authenticatedUser());
+
+        Assert.assertFalse(isUserStoreDomainBlocked(context),
+                "An unknown username must never be flagged as blocked, that would leak whether it exists.");
+        Assert.assertEquals(result.getUserStoreDomain(), SECONDARY_DOMAIN_TWO,
+                "An unresolved user must keep the last walked domain rather than the incoming one.");
+    }
+
+    @Test(description = "Username exists in the primary store while only a secondary store is blocked -> untouched.")
+    public void testDoesNotFlagPrimaryUserWhenOnlySecondaryDomainIsBlocked() throws Exception {
+
+        givenBlockedUserStoreDomains(SECONDARY_DOMAIN_ONE);
+        givenExistingUsers(USERNAME);
+
+        AuthenticationContext context = context();
+        AuthenticatedUser result = fidoAuthenticator.normalizeAuthenticatedUser(context, authenticatedUser());
+
+        Assert.assertEquals(result.getUserStoreDomain(), PRIMARY_DOMAIN,
+                "A user found in an unblocked primary store must keep the primary domain.");
+        Assert.assertFalse(isUserStoreDomainBlocked(context),
+                "A user in an unblocked domain must not be flagged as blocked.");
+    }
+
+    @Test(description = "No blocked domains configured -> resolution is unchanged and nothing is ever flagged. " +
+            "This is the regression guard for deployments that do not set the configuration.")
+    public void testResolutionUnchangedWhenNoDomainsAreBlocked() throws Exception {
+
+        givenExistingUsers(USERNAME_IN_SECONDARY_ONE);
+
+        AuthenticationContext context = context();
+        AuthenticatedUser result = fidoAuthenticator.normalizeAuthenticatedUser(context, authenticatedUser());
+
+        Assert.assertEquals(result.getUserStoreDomain(), SECONDARY_DOMAIN_ONE,
+                "Without the configuration the user must resolve exactly as before.");
+        Assert.assertFalse(isUserStoreDomainBlocked(context),
+                "Nothing can be blocked when no domains are configured.");
+    }
+
+    @Test(description = "Configured domains are trimmed and upper cased before comparison, so a value written " +
+            "with spaces or in lower case still matches.")
+    public void testTrimsAndUpperCasesConfiguredDomains() throws Exception {
+
+        givenBlockedUserStoreDomains(" primary , sec1 ");
+        givenExistingUsers(USERNAME);
+
+        AuthenticationContext context = context();
+        fidoAuthenticator.normalizeAuthenticatedUser(context, authenticatedUser());
+
+        Assert.assertTrue(isUserStoreDomainBlocked(context),
+                "A configured domain must match regardless of surrounding spaces and case.");
+    }
+
+    private AuthenticationContext context() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setTenantDomain(TENANT_DOMAIN);
+        return context;
+    }
+
+    private AuthenticatedUser authenticatedUser() {
+
+        AuthenticatedUser user = new AuthenticatedUser();
+        user.setUserName(USERNAME);
+        user.setUserStoreDomain(PRIMARY_DOMAIN);
+        user.setTenantDomain(TENANT_DOMAIN);
+        return user;
+    }
+
+    private RealmConfiguration realmConfiguration(String domainName) {
+
+        RealmConfiguration realmConfiguration = new RealmConfiguration();
+        Map<String, String> userStoreProperties = new HashMap<>();
+        userStoreProperties.put(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME, domainName);
+        realmConfiguration.setUserStoreProperties(userStoreProperties);
+        return realmConfiguration;
+    }
+
+    private void givenBlockedUserStoreDomains(String blockedUserStoreDomains) {
+
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        Map<String, String> parameterMap = new HashMap<>();
+        if (blockedUserStoreDomains != null) {
+            parameterMap.put(BLOCKED_USERSTORE_DOMAINS_LIST, blockedUserStoreDomains);
+        }
+        authenticatorConfig.setParameterMap(parameterMap);
+        when(fileBasedConfigurationBuilder.getAuthenticatorBean(FIDOAuthenticatorConstants.AUTHENTICATOR_NAME))
+                .thenReturn(authenticatorConfig);
+    }
+
+    private void givenExistingUsers(String... existingUsernames) throws Exception {
+
+        for (String existingUsername : existingUsernames) {
+            when(primaryUserStoreManager.isExistingUser(existingUsername)).thenReturn(true);
+        }
+    }
+
+    private boolean isUserStoreDomainBlocked(AuthenticationContext context) {
+
+        return Boolean.TRUE.equals(context.getProperty(IS_USER_STORE_DOMAIN_BLOCKED));
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorNormalizeUsernameTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorNormalizeUsernameTest.java
@@ -27,6 +27,8 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -39,6 +41,8 @@ import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.tenant.TenantManager;
+
+import java.util.HashMap;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
@@ -67,10 +71,13 @@ public class FIDOAuthenticatorNormalizeUsernameTest {
     private UserRealm userRealm;
     @Mock
     private AbstractUserStoreManager userStoreManager;
+    @Mock
+    private FileBasedConfigurationBuilder fileBasedConfigurationBuilder;
 
     private MockedStatic<IdentityUtil> identityUtilMock;
     private MockedStatic<FIDOUtil> fidoUtilMock;
     private MockedStatic<FIDOAuthenticatorServiceComponent> fidoAuthenticatorServiceComponentMock;
+    private MockedStatic<FileBasedConfigurationBuilder> fileBasedConfigurationBuilderMock;
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -81,6 +88,15 @@ public class FIDOAuthenticatorNormalizeUsernameTest {
         identityUtilMock = mockStatic(IdentityUtil.class);
         fidoUtilMock = mockStatic(FIDOUtil.class);
         fidoAuthenticatorServiceComponentMock = mockStatic(FIDOAuthenticatorServiceComponent.class);
+        fileBasedConfigurationBuilderMock = mockStatic(FileBasedConfigurationBuilder.class);
+
+        // normalizeAuthenticatedUser reads the BlockedUserStoreDomains parameter. These tests do not block any
+        // domain, so an empty parameter map is enough.
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        authenticatorConfig.setParameterMap(new HashMap<>());
+        fileBasedConfigurationBuilderMock.when(FileBasedConfigurationBuilder::getInstance)
+                .thenReturn(fileBasedConfigurationBuilder);
+        when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(authenticatorConfig);
 
         fidoAuthenticatorServiceComponentMock.when(FIDOAuthenticatorServiceComponent::getRealmService)
                 .thenReturn(realmService);
@@ -107,6 +123,9 @@ public class FIDOAuthenticatorNormalizeUsernameTest {
         }
         if (fidoAuthenticatorServiceComponentMock != null) {
             fidoAuthenticatorServiceComponentMock.close();
+        }
+        if (fileBasedConfigurationBuilderMock != null) {
+            fileBasedConfigurationBuilderMock.close();
         }
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticatorTest.java
@@ -696,10 +696,20 @@ public class FIDOAuthenticatorTest {
         identityUtilMock.when(IdentityUtil::getPrimaryDomainName).thenReturn(USER_STORE_DOMAIN);
         when(httpServletRequest.getAttribute(FrameworkConstants.IS_API_BASED_AUTH_FLOW)).thenReturn(Boolean.TRUE);
 
+        AuthenticatorConfig blockedDomainsConfig = new AuthenticatorConfig();
+        blockedDomainsConfig.setParameterMap(new HashMap<>());
+
         try (MockedStatic<FIDOUtil> fidoUtilMock = mockStatic(FIDOUtil.class);
              MockedStatic<FrameworkUtils> frameworkUtilsMock = mockStatic(FrameworkUtils.class);
+             MockedStatic<FileBasedConfigurationBuilder> configBuilderMock =
+                     mockStatic(FileBasedConfigurationBuilder.class);
              MockedConstruction<WebAuthnService> ignored = Mockito.mockConstruction(WebAuthnService.class,
                      (mock, ctx) -> when(mock.isFidoKeyRegistered(any(AuthenticatedUser.class))).thenReturn(false))) {
+
+            // process() reads the BlockedUserStoreDomains parameter for every identified user.
+            configBuilderMock.when(FileBasedConfigurationBuilder::getInstance)
+                    .thenReturn(fileBasedConfigurationBuilder);
+            when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(blockedDomainsConfig);
 
             AuthenticatorFlowStatus status = fidoAuthenticator.process(
                     httpServletRequest, httpServletResponse, context);

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/test/resources/testng.xml
@@ -24,6 +24,7 @@
         <classes>
             <class name="org.wso2.carbon.identity.application.authenticator.fido.FIDOAuthenticatorTest" />
             <class name="org.wso2.carbon.identity.application.authenticator.fido.FIDOAuthenticatorNormalizeUsernameTest" />
+            <class name="org.wso2.carbon.identity.application.authenticator.fido.FIDOAuthenticatorBlockedUserStoreDomainTest" />
             <class name="org.wso2.carbon.identity.application.authenticator.fido.service.FIDOAdminServiceTest" />
             <class name="org.wso2.carbon.identity.application.authenticator.fido.u2f.U2FServiceTest" />
         </classes>


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-is/issues/28228

When the same username exists in both the primary and a secondary user store, and the passkey is registered against the **secondary** user, passkey authentication fails with "passkey not configured".

`normalizeAuthenticatedUser` resolves a bare username by calling `isExistingUser(username)`, which only reports on the primary store. If a user with that username also exists in the primary store, the check returns `true`, the loop that walks the secondary stores is skipped, and the user resolves to `PRIMARY/<username>`. FIDO2 credentials are keyed by user store domain, so the lookup finds nothing.

## Approach

The FIDO authenticator now reads the `BlockedUserStoreDomains` parameter, so a deployment can exclude a user store domain from passkey authentication. When the primary domain is blocked, resolution continues into the secondary stores instead of stopping at the primary match.

This reuses the parameter name and format already used by `AbstractApplicationAuthenticator.getValidUsers`.

Two details worth review:

**A user found only in a blocked domain is tracked in a context property, not in the resolved domain.** When no store matches, the walk deliberately leaves the user on the last domain it looked at, so the rest of the flow looks the same as it does for a user with no enrolled passkeys. That domain is not the blocked one, so it cannot carry the blocked state. Without the property, a user who exists only in a blocked store is relabelled with an unblocked domain and passes the block.

**Configured domain names are trimmed and upper cased.** They are compared against `UserCoreUtil.getDomainName`, which upper cases. Previously `BlockedUserStoreDomains = "PRIMARY, SECONDARY"` produced `" SECONDARY"`, matched nothing, and disabled the block with no error anywhere.

`getUserStoreManagerDomainName` is also null safe now, since `UserCoreUtil.getDomainName` dereferences the realm configuration and the new code applies it to the primary store manager, which the previous code never did.

## Configuration

Not enabled by default. With the parameter unset, resolution is byte-for-byte what it was before.

```toml
[authentication.authenticator.fido.parameters]
BlockedUserStoreDomains = "PRIMARY"
```

This is a deployment-wide setting, not per tenant.

## Verification

Unit tests: 55 passed, 0 failed (JDK 21). Eight new cases in `FIDOAuthenticatorBlockedUserStoreDomainTest` cover resolution past a blocked primary, a user found only in a blocked primary, a user found only in a blocked secondary, an unknown username, a primary user when only a secondary is blocked, and an unset configuration.

Manually verified on a `7.4.0-SNAPSHOT` pack with a secondary JDBC user store (`SECONDARY`), the user `alise` present in **both** PRIMARY and SECONDARY, and a passkey registered against `SECONDARY/alise`. Login flow was Identifier First → Passkey.

| # | Scenario | Result |
|---|---|---|
| 1 | `BlockedUserStoreDomains = "PRIMARY"`, sign in as `alise` | Passkey challenge shown for `SECONDARY/alise`, credential found. **The reported bug is fixed.** |
| 2 | Same, with the configuration removed | "No enrolled passkey found". The bug reproduces, confirming the setup is genuinely the reported scenario and that this change does nothing when unconfigured. |
| 3 | `BlockedUserStoreDomains = "PRIMARY"`, sign in as `admin` | Correctly blocked. See below. |
| 4 | `BlockedUserStoreDomains = " primary , secondary "`, sign in as `alise` | Correctly blocked. See below. |
| 5 | Unknown username with a domain blocked | Identical page to a real user with no passkey. No way to tell from the outside whether the username exists. |
| 6 | Progressive enrollment enabled, blocked user | Not enrolled. See note below. |

### Scenario 3, explained

`admin` exists only in PRIMARY, and PRIMARY is the blocked domain. The stores are walked in the order PRIMARY → AGENT → SECONDARY.

Because PRIMARY is blocked, the walk runs, but `admin` is not in AGENT or SECONDARY so nothing matches. The walk still leaves the user on SECONDARY, the last store it looked at. At that point the user object says `SECONDARY/admin` — and SECONDARY is not a blocked domain.

So the plain "is this user's domain blocked?" check comes back **false**, and it is the context property that blocks the login. That is the whole reason the property exists. Without it, `admin` — a user sitting in a store the deployment deliberately blocked — would sail through as a SECONDARY user who does not actually exist there.

### Scenario 4, explained

The configured value here is deliberately messy: lower case, with spaces around the comma and at both ends.

Domain names come back from the server in upper case (`PRIMARY`, `SECONDARY`). The original parsing split on the comma and compared the pieces as-is, which gives `" primary "` and `" secondary "` — neither matches anything. The block would have quietly done nothing at all: no error, no warning, no log line, just a security setting silently switched off because someone put a space after a comma.

With the trimming and upper casing in this PR, both entries match and `alise` is blocked as intended. The point of the test is the failure mode: this setting fails **open**, so it has to be forgiving about formatting.

### Note on progressive enrollment (scenario 6)

With progressive enrollment enabled and PRIMARY blocked, a blocked user is not enrolled and no row is written to `FIDO2_DEVICE_STORE`.

However, the control run shows this is not attributable to this change: with **nothing** blocked, a fresh session and no `prompt=login`, clicking "Create a passkey" after Identifier First also does not enrol, ending in `login_required`. This is by design — [`FIDOAuthenticator#process`](https://github.com/wso2-extensions/identity-local-auth-fido/blob/master/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java#L259) refuses to enrol when the previous step was a flow handler. Identifier First does not authenticate anyone, so enrolling there would let anyone who knows a username register a passkey and log in as that user.

Recording it so the scope of this change is not overstated: it is justified by scenario 3, not by any enrollment behaviour.

## Related issue

Not covered by this PR, and worth deciding separately: the blocked redirect and the enrollment consent redirect resolve to the same URL (`fido2-passkey-status.jsp` with `keyExist=false`). With progressive enrollment on, a blocked user is therefore shown a "Create a passkey" button that loops back to the same page. Good for indistinguishability, poor as UX.

## Checklist

- [x] Unit tests added
- [x] Manually verified
- [x] Introduces a new configuration (`BlockedUserStoreDomains`), documented above. Off by default.
- [ ] Documentation update
