### PR TITLE
[Temporary][Do not release] Add AUTHDIAG logs across the FIDO user resolution path

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -185,7 +185,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             // status page instead of a challenge.
             log.info("AUTHDIAG fido-block-gate step=" + context.getCurrentStep()
                     + " domain=" + authenticatedUser.getUserStoreDomain()
-                    + " userIdSet=" + authenticatedUser.isUserIdExists()
+                    + " userId=" + authDiagUserId(authenticatedUser)
                     + " resolvedDomainBlocked=" + isResolvedDomainBlocked
                     + " onlyInBlockedDomains=" + existsOnlyInBlockedDomains
                     + " willBlock=" + (isResolvedDomainBlocked || existsOnlyInBlockedDomains));
@@ -573,13 +573,13 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             log.info("AUTHDIAG fido-assertion webAuthn=" + isWebAuthnEnabled()
                     + " path=" + (user == null ? "usernameless" : "username")
                     + " inDomain=" + (user == null ? null : user.getUserStoreDomain())
-                    + " inUserIdSet=" + (user != null && user.isUserIdExists()));
+                    + " inUserId=" + authDiagUserId(user));
             if (isWebAuthnEnabled()) {
                 if (user == null) {
                     user = processFido2UsernamelessAuthenticationResponse(tokenResponse);
                     // AUTHDIAG (temporary) - the user the credential itself resolved to.
                     log.info("AUTHDIAG fido-usernameless-resolved domain=" + user.getUserStoreDomain()
-                            + " tenant=" + user.getTenantDomain() + " userIdSet=" + user.isUserIdExists());
+                            + " tenant=" + user.getTenantDomain() + " userId=" + authDiagUserId(user));
                 } else {
                     processFido2AuthenticationResponse(user, tokenResponse);
                 }
@@ -591,7 +591,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             // AUTHDIAG (temporary) - the subject FIDO hands back to the framework. This is the identity
             // that ends up as sub and drives claim resolution.
             log.info("AUTHDIAG fido-subject domain=" + user.getUserStoreDomain()
-                    + " tenant=" + user.getTenantDomain() + " userIdSet=" + user.isUserIdExists()
+                    + " tenant=" + user.getTenantDomain() + " userId=" + authDiagUserId(user)
                     + " federated=" + user.isFederatedUser());
             context.setSubject(user);
 
@@ -895,7 +895,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         log.info("AUTHDIAG fido-mal-gate previousIsFlowHandler=" + prevIsFlowHandler
                 + " userNull=" + (user == null)
                 + " domain=" + (user == null ? null : user.getUserStoreDomain())
-                + " userIdSet=" + (user != null && user.isUserIdExists()));
+                + " userId=" + authDiagUserId(user));
         if (prevIsFlowHandler) {
             boolean isUserResolved = FrameworkUtils.getIsUserResolved(context);
             log.info("AUTHDIAG fido-mal-gate isUserResolved=" + isUserResolved);
@@ -910,7 +910,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                 if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS
                         .equals(resolvedUserResult.getResolvedStatus())) {
                     // AUTHDIAG (temporary) - the FIDO connector overwriting the user id here.
-                    log.info("AUTHDIAG fido-mal-set oldUserIdSet=" + user.isUserIdExists()
+                    log.info("AUTHDIAG fido-mal-set oldUserId=" + authDiagUserId(user)
                             + " oldDomain=" + user.getUserStoreDomain()
                             + " newUserId=" + resolvedUserResult.getUser().getUserID()
                             + " newDomain=" + resolvedUserResult.getUser().getUserStoreDomain());
@@ -958,7 +958,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         log.info("AUTHDIAG fido-challenge mode=" + (user == null || !hasPasskeys ? "usernameless" : "username")
                 + " domain=" + (user == null ? null : user.getUserStoreDomain())
                 + " tenant=" + (user == null ? null : user.getTenantDomain())
-                + " userIdSet=" + (user != null && user.isUserIdExists())
+                + " userId=" + authDiagUserId(user)
                 + " hasPasskeys=" + hasPasskeys);
         if (user == null || !hasPasskeys) {
             if (resolvedRpId != null) {
@@ -1124,6 +1124,28 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
      * @param authenticatedUser AuthenticationContext.
      * @return User id.
      */
+    /**
+     * AUTHDIAG (temporary). Reads the user id for logging <b>without</b> resolving it.
+     * <p>
+     * {@link AuthenticatedUser#getUserId()} resolves against the user store and caches the result
+     * when the id is not already set, so calling it from a log statement would bind the id and
+     * change the behaviour being investigated. {@link AuthenticatedUser#isUserIdExists()} is a plain
+     * null check, and getUserId() short circuits to the cached value once it passes.
+     *
+     * @return the user id if already resolved, otherwise null.
+     */
+    private static String authDiagUserId(AuthenticatedUser user) {
+
+        if (user == null || !user.isUserIdExists()) {
+            return null;
+        }
+        try {
+            return user.getUserId();
+        } catch (UserIdNotFoundException e) {
+            return "unresolved";
+        }
+    }
+
     private Optional<String> getUserId(AuthenticatedUser authenticatedUser) {
 
         if (authenticatedUser == null) {
@@ -1154,7 +1176,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                 // AUTHDIAG (temporary) - resolved from the subject attribute step.
                 log.info("AUTHDIAG fido-getuser source=subjectAttributeStep step=" + stepConfig.getOrder()
                         + " domain=" + authenticatedUserInStepConfig.getUserStoreDomain()
-                        + " userIdSet=" + authenticatedUserInStepConfig.isUserIdExists());
+                        + " userId=" + authDiagUserId(authenticatedUserInStepConfig));
                 return handleIdentifierFirstNormalization(context, authenticatedUserInStepConfig);
             }
         }
@@ -1162,7 +1184,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             // AUTHDIAG (temporary) - fell back to the last authenticated user.
             log.info("AUTHDIAG fido-getuser source=lastAuthenticatedUser"
                     + " domain=" + context.getLastAuthenticatedUser().getUserStoreDomain()
-                    + " userIdSet=" + context.getLastAuthenticatedUser().isUserIdExists());
+                    + " userId=" + authDiagUserId(context.getLastAuthenticatedUser()));
             return handleIdentifierFirstNormalization(context, context.getLastAuthenticatedUser());
         }
         // AUTHDIAG (temporary) - no user identified; the usernameless path follows.
@@ -1501,7 +1523,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                     + " existsInPrimary=" + existsInPrimaryDomain
                     + " primaryBlocked=" + isPrimaryDomainBlocked
                     + " blockedList=" + blockedUserStoreDomainsList
-                    + " userIdSet=" + authenticatedUser.isUserIdExists());
+                    + " userId=" + authDiagUserId(authenticatedUser));
 
             boolean secondaryWalkRan = (isPrimaryDomainBlocked || !existsInPrimaryDomain) && !isDomainQualified;
             log.info("AUTHDIAG fido-normalize-walk willWalkSecondaries=" + secondaryWalkRan);
@@ -1573,7 +1595,7 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
 
         // AUTHDIAG (temporary) - this method sets the domain but never the user id.
         log.info("AUTHDIAG fido-normalize outDomain=" + authenticatedUser.getUserStoreDomain()
-                + " userIdSet=" + authenticatedUser.isUserIdExists());
+                + " userId=" + authDiagUserId(authenticatedUser));
 
         return authenticatedUser;
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -889,14 +889,13 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
 
         WebAuthnService webAuthnService = new WebAuthnService();
 
-        boolean prevIsFlowHandler = FrameworkUtils.isPreviousIdPAuthenticationFlowHandler(context);
         // AUTHDIAG (temporary) - gate on the branch below, which is one of the few places the FIDO
         // connector itself writes the user id.
-        log.info("AUTHDIAG fido-mal-gate previousIsFlowHandler=" + prevIsFlowHandler
-                + " userNull=" + (user == null)
+        log.info("AUTHDIAG fido-mal-gate userNull=" + (user == null)
                 + " domain=" + (user == null ? null : user.getUserStoreDomain())
                 + " userId=" + authDiagUserId(user));
-        if (prevIsFlowHandler) {
+        if (FrameworkUtils.isPreviousIdPAuthenticationFlowHandler(context)) {
+            log.info("AUTHDIAG fido-mal-gate previousIsFlowHandler=true");
             boolean isUserResolved = FrameworkUtils.getIsUserResolved(context);
             log.info("AUTHDIAG fido-mal-gate isUserResolved=" + isUserResolved);
             if (!isUserResolved && user != null) {
@@ -953,20 +952,22 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
 
         //Initiate the usernameless authentication process when either the user is unidentified or the identified user
         // lacks an enrolled passkey.
-        boolean hasPasskeys = user != null && hasUserSetPasskeys(user);
-        // AUTHDIAG (temporary) - which challenge is issued, and the identity the passkey lookup used.
-        log.info("AUTHDIAG fido-challenge mode=" + (user == null || !hasPasskeys ? "usernameless" : "username")
+        // AUTHDIAG (temporary) - the identity the passkey lookup is about to use.
+        log.info("AUTHDIAG fido-challenge userNull=" + (user == null)
                 + " domain=" + (user == null ? null : user.getUserStoreDomain())
                 + " tenant=" + (user == null ? null : user.getTenantDomain())
-                + " userId=" + authDiagUserId(user)
-                + " hasPasskeys=" + hasPasskeys);
-        if (user == null || !hasPasskeys) {
+                + " userId=" + authDiagUserId(user));
+        if (user == null || !hasUserSetPasskeys(user)) {
+            // AUTHDIAG (temporary) - no identified user, or no passkey for the identity above.
+            log.info("AUTHDIAG fido-challenge mode=usernameless");
             if (resolvedRpId != null) {
                 return webAuthnService.startUsernamelessAuthenticationWithRpId(resolvedRpId, rpName, effectiveAppId);
             }
             return webAuthnService.startUsernamelessAuthentication(appID);
         }
 
+        // AUTHDIAG (temporary) - a passkey was found for the identity above.
+        log.info("AUTHDIAG fido-challenge mode=username domain=" + user.getUserStoreDomain());
         if (resolvedRpId != null) {
             return webAuthnService.startAuthenticationWithRpId(resolvedRpId, rpName, user.getUserName(),
                     user.getTenantDomain(), user.getUserStoreDomain(), effectiveAppId);
@@ -1525,10 +1526,9 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                     + " blockedList=" + blockedUserStoreDomainsList
                     + " userId=" + authDiagUserId(authenticatedUser));
 
-            boolean secondaryWalkRan = (isPrimaryDomainBlocked || !existsInPrimaryDomain) && !isDomainQualified;
-            log.info("AUTHDIAG fido-normalize-walk willWalkSecondaries=" + secondaryWalkRan);
-
-            if (secondaryWalkRan) {
+            if ((isPrimaryDomainBlocked || !existsInPrimaryDomain) && !isDomainQualified) {
+                // AUTHDIAG (temporary) - the secondary store walk.
+                log.info("AUTHDIAG fido-normalize-walk started=true");
                 UserStoreManager secondary = userStoreManager.getSecondaryUserStoreManager();
                 while (secondary != null) {
                     userStoreDomain = getUserStoreManagerDomainName(secondary);
@@ -1536,12 +1536,11 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                     if (StringUtils.isNotBlank(userStoreDomain)) {
                         final String domainQualifiedUsername =
                                 UserCoreUtil.addDomainToName(username, userStoreDomain);
-                        boolean existsHere = userStoreManager.isExistingUser(domainQualifiedUsername);
                         // AUTHDIAG (temporary) - each secondary store considered.
                         log.info("AUTHDIAG fido-normalize-try domain=" + userStoreDomain
-                                + " exists=" + existsHere
                                 + " blocked=" + blockedUserStoreDomainsList.contains(userStoreDomain));
-                        if (existsHere) {
+                        if (userStoreManager.isExistingUser(domainQualifiedUsername)) {
+                            log.info("AUTHDIAG fido-normalize-try domain=" + userStoreDomain + " exists=true");
                             if (!blockedUserStoreDomainsList.contains(userStoreDomain)) {
                                 isUserResolved = true;
                                 break;
@@ -1566,11 +1565,10 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             // still matches the stored passkey.
             String caseDomain = StringUtils.isNotBlank(userStoreDomain)
                     ? userStoreDomain : IdentityUtil.getPrimaryDomainName();
-            boolean caseSensitiveStore = IdentityUtil.isUserStoreCaseSensitive(caseDomain, tenantId);
             // AUTHDIAG (temporary) - the passkey username normalisation branch.
-            log.info("AUTHDIAG fido-normalize-case caseDomain=" + caseDomain
-                    + " caseSensitive=" + caseSensitiveStore);
-            if (!caseSensitiveStore) {
+            log.info("AUTHDIAG fido-normalize-case caseDomain=" + caseDomain);
+            if (!IdentityUtil.isUserStoreCaseSensitive(caseDomain, tenantId)) {
+                log.info("AUTHDIAG fido-normalize-case caseSensitive=false");
                 String storedUsername = resolveStoredPasskeyUsername(
                         FIDOUtil.getUsernameWithoutDomain(username), tenantDomain, userStoreDomain);
                 // Usernames are not logged; only whether one was found and whether it differed.
@@ -1624,16 +1622,17 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             throws AuthenticationFailedException {
 
         List<AuthHistory> authHistory = context.getAuthenticationStepHistory();
-        String firstAuthenticator = (authHistory != null && !authHistory.isEmpty())
-                ? authHistory.get(0).getAuthenticatorName() : null;
-        boolean willNormalize = IDF_AUTHENTICATOR.equals(firstAuthenticator);
         // AUTHDIAG (temporary) - normalisation only runs when identifier first was the first step.
-        log.info("AUTHDIAG fido-idf-check firstAuthenticator=" + firstAuthenticator
-                + " expected=" + IDF_AUTHENTICATOR + " willNormalize=" + willNormalize
-                + " historySize=" + (authHistory == null ? -1 : authHistory.size()));
-        if (willNormalize) {
+        log.info("AUTHDIAG fido-idf-check historySize=" + (authHistory == null ? -1 : authHistory.size())
+                + " firstAuthenticator=" + (authHistory == null || authHistory.isEmpty() ? null
+                        : authHistory.get(0).getAuthenticatorName())
+                + " expected=" + IDF_AUTHENTICATOR);
+        if (authHistory != null && !authHistory.isEmpty() &&
+                IDF_AUTHENTICATOR.equals(authHistory.get(0).getAuthenticatorName())) {
+            log.info("AUTHDIAG fido-idf-check normalizing=true");
             return normalizeAuthenticatedUser(context, user);
         } else {
+            log.info("AUTHDIAG fido-idf-check normalizing=false");
             return user;
         }
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -181,6 +181,15 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             boolean existsOnlyInBlockedDomains =
                     Boolean.TRUE.equals(context.getProperty(IS_USER_STORE_DOMAIN_BLOCKED));
 
+            // AUTHDIAG (temporary) - the blocked domain gate, which sends the user to the passkey
+            // status page instead of a challenge.
+            log.info("AUTHDIAG fido-block-gate step=" + context.getCurrentStep()
+                    + " domain=" + authenticatedUser.getUserStoreDomain()
+                    + " userIdSet=" + authenticatedUser.isUserIdExists()
+                    + " resolvedDomainBlocked=" + isResolvedDomainBlocked
+                    + " onlyInBlockedDomains=" + existsOnlyInBlockedDomains
+                    + " willBlock=" + (isResolvedDomainBlocked || existsOnlyInBlockedDomains));
+
             if (isResolvedDomainBlocked || existsOnlyInBlockedDomains) {
                 String blockReason = isResolvedDomainBlocked
                         ? "The user store domain: " + authenticatedUser.getUserStoreDomain() +
@@ -560,9 +569,17 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             tokenResponse = base64URLDecode(request.getParameter(TOKEN_RESPONSE));
         }
         if (tokenResponse != null && !tokenResponse.contains(ERROR_CODE)) {
+            // AUTHDIAG (temporary) - which assertion path handles the response.
+            log.info("AUTHDIAG fido-assertion webAuthn=" + isWebAuthnEnabled()
+                    + " path=" + (user == null ? "usernameless" : "username")
+                    + " inDomain=" + (user == null ? null : user.getUserStoreDomain())
+                    + " inUserIdSet=" + (user != null && user.isUserIdExists()));
             if (isWebAuthnEnabled()) {
                 if (user == null) {
                     user = processFido2UsernamelessAuthenticationResponse(tokenResponse);
+                    // AUTHDIAG (temporary) - the user the credential itself resolved to.
+                    log.info("AUTHDIAG fido-usernameless-resolved domain=" + user.getUserStoreDomain()
+                            + " tenant=" + user.getTenantDomain() + " userIdSet=" + user.isUserIdExists());
                 } else {
                     processFido2AuthenticationResponse(user, tokenResponse);
                 }
@@ -571,6 +588,11 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                 processFidoAuthenticationResponse(user, appID, tokenResponse);
             }
             user.setAuthenticatedSubjectIdentifier(user.getUsernameAsSubjectIdentifier(true, true));
+            // AUTHDIAG (temporary) - the subject FIDO hands back to the framework. This is the identity
+            // that ends up as sub and drives claim resolution.
+            log.info("AUTHDIAG fido-subject domain=" + user.getUserStoreDomain()
+                    + " tenant=" + user.getTenantDomain() + " userIdSet=" + user.isUserIdExists()
+                    + " federated=" + user.isFederatedUser());
             context.setSubject(user);
 
             // Check account lock status before completing the authentication.
@@ -867,15 +889,31 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
 
         WebAuthnService webAuthnService = new WebAuthnService();
 
-        if (FrameworkUtils.isPreviousIdPAuthenticationFlowHandler(context)) {
+        boolean prevIsFlowHandler = FrameworkUtils.isPreviousIdPAuthenticationFlowHandler(context);
+        // AUTHDIAG (temporary) - gate on the branch below, which is one of the few places the FIDO
+        // connector itself writes the user id.
+        log.info("AUTHDIAG fido-mal-gate previousIsFlowHandler=" + prevIsFlowHandler
+                + " userNull=" + (user == null)
+                + " domain=" + (user == null ? null : user.getUserStoreDomain())
+                + " userIdSet=" + (user != null && user.isUserIdExists()));
+        if (prevIsFlowHandler) {
             boolean isUserResolved = FrameworkUtils.getIsUserResolved(context);
+            log.info("AUTHDIAG fido-mal-gate isUserResolved=" + isUserResolved);
             if (!isUserResolved && user != null) {
                 String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(user.toFullQualifiedUsername());
                 String tenantDomain = MultitenantUtils.getTenantDomain(user.toFullQualifiedUsername());
                 ResolvedUserResult resolvedUserResult = FrameworkUtils.
                         processMultiAttributeLoginIdentification(tenantAwareUsername, tenantDomain);
+                // AUTHDIAG (temporary) - multi attribute login resolution outcome.
+                log.info("AUTHDIAG fido-mal-result null=" + (resolvedUserResult == null)
+                        + " status=" + (resolvedUserResult == null ? null : resolvedUserResult.getResolvedStatus()));
                 if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS
                         .equals(resolvedUserResult.getResolvedStatus())) {
+                    // AUTHDIAG (temporary) - the FIDO connector overwriting the user id here.
+                    log.info("AUTHDIAG fido-mal-set oldUserIdSet=" + user.isUserIdExists()
+                            + " oldDomain=" + user.getUserStoreDomain()
+                            + " newUserId=" + resolvedUserResult.getUser().getUserID()
+                            + " newDomain=" + resolvedUserResult.getUser().getUserStoreDomain());
                     user.setUserName(resolvedUserResult.getUser().getUsername());
                     user.setUserId(resolvedUserResult.getUser().getUserID());
                     user.setUserStoreDomain(resolvedUserResult.getUser().getUserStoreDomain());
@@ -915,7 +953,14 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
 
         //Initiate the usernameless authentication process when either the user is unidentified or the identified user
         // lacks an enrolled passkey.
-        if (user == null || !hasUserSetPasskeys(user)) {
+        boolean hasPasskeys = user != null && hasUserSetPasskeys(user);
+        // AUTHDIAG (temporary) - which challenge is issued, and the identity the passkey lookup used.
+        log.info("AUTHDIAG fido-challenge mode=" + (user == null || !hasPasskeys ? "usernameless" : "username")
+                + " domain=" + (user == null ? null : user.getUserStoreDomain())
+                + " tenant=" + (user == null ? null : user.getTenantDomain())
+                + " userIdSet=" + (user != null && user.isUserIdExists())
+                + " hasPasskeys=" + hasPasskeys);
+        if (user == null || !hasPasskeys) {
             if (resolvedRpId != null) {
                 return webAuthnService.startUsernamelessAuthenticationWithRpId(resolvedRpId, rpName, effectiveAppId);
             }
@@ -1106,12 +1151,22 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
         for (StepConfig stepConfig : stepConfigMap.values()) {
             AuthenticatedUser authenticatedUserInStepConfig = stepConfig.getAuthenticatedUser();
             if (stepConfig.isSubjectAttributeStep() && authenticatedUserInStepConfig != null) {
+                // AUTHDIAG (temporary) - resolved from the subject attribute step.
+                log.info("AUTHDIAG fido-getuser source=subjectAttributeStep step=" + stepConfig.getOrder()
+                        + " domain=" + authenticatedUserInStepConfig.getUserStoreDomain()
+                        + " userIdSet=" + authenticatedUserInStepConfig.isUserIdExists());
                 return handleIdentifierFirstNormalization(context, authenticatedUserInStepConfig);
             }
         }
         if (context.getLastAuthenticatedUser() != null && context.getLastAuthenticatedUser().getUserName() != null) {
+            // AUTHDIAG (temporary) - fell back to the last authenticated user.
+            log.info("AUTHDIAG fido-getuser source=lastAuthenticatedUser"
+                    + " domain=" + context.getLastAuthenticatedUser().getUserStoreDomain()
+                    + " userIdSet=" + context.getLastAuthenticatedUser().isUserIdExists());
             return handleIdentifierFirstNormalization(context, context.getLastAuthenticatedUser());
         }
+        // AUTHDIAG (temporary) - no user identified; the usernameless path follows.
+        log.info("AUTHDIAG fido-getuser source=none");
         return null;
     }
 
@@ -1438,7 +1493,20 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             boolean isUserResolved = false;
             boolean existsInBlockedDomain = isPrimaryDomainBlocked && existsInPrimaryDomain;
 
-            if ((isPrimaryDomainBlocked || !existsInPrimaryDomain) && !isDomainQualified) {
+            // AUTHDIAG (temporary) - the inputs to the domain decision.
+            log.info("AUTHDIAG fido-normalize-in inDomain=" + userStoreDomain
+                    + " primaryStoreDomain=" + userStoreManagerDomain
+                    + " storeClass=" + userStoreManager.getClass().getSimpleName()
+                    + " domainQualified=" + isDomainQualified
+                    + " existsInPrimary=" + existsInPrimaryDomain
+                    + " primaryBlocked=" + isPrimaryDomainBlocked
+                    + " blockedList=" + blockedUserStoreDomainsList
+                    + " userIdSet=" + authenticatedUser.isUserIdExists());
+
+            boolean secondaryWalkRan = (isPrimaryDomainBlocked || !existsInPrimaryDomain) && !isDomainQualified;
+            log.info("AUTHDIAG fido-normalize-walk willWalkSecondaries=" + secondaryWalkRan);
+
+            if (secondaryWalkRan) {
                 UserStoreManager secondary = userStoreManager.getSecondaryUserStoreManager();
                 while (secondary != null) {
                     userStoreDomain = getUserStoreManagerDomainName(secondary);
@@ -1446,7 +1514,12 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                     if (StringUtils.isNotBlank(userStoreDomain)) {
                         final String domainQualifiedUsername =
                                 UserCoreUtil.addDomainToName(username, userStoreDomain);
-                        if (userStoreManager.isExistingUser(domainQualifiedUsername)) {
+                        boolean existsHere = userStoreManager.isExistingUser(domainQualifiedUsername);
+                        // AUTHDIAG (temporary) - each secondary store considered.
+                        log.info("AUTHDIAG fido-normalize-try domain=" + userStoreDomain
+                                + " exists=" + existsHere
+                                + " blocked=" + blockedUserStoreDomainsList.contains(userStoreDomain));
+                        if (existsHere) {
                             if (!blockedUserStoreDomainsList.contains(userStoreDomain)) {
                                 isUserResolved = true;
                                 break;
@@ -1458,6 +1531,12 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
                 }
             }
 
+            // AUTHDIAG (temporary) - the outcome of the domain decision.
+            log.info("AUTHDIAG fido-normalize-out resolved=" + isUserResolved
+                    + " existsInBlockedDomain=" + existsInBlockedDomain
+                    + " chosenDomain=" + userStoreDomain
+                    + " markedBlocked=" + (existsInBlockedDomain && !isUserResolved));
+
             context.setProperty(IS_USER_STORE_DOMAIN_BLOCKED, existsInBlockedDomain && !isUserResolved);
 
             // On a case-insensitive store, resolve the username to the case under which the passkey was
@@ -1465,9 +1544,17 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             // still matches the stored passkey.
             String caseDomain = StringUtils.isNotBlank(userStoreDomain)
                     ? userStoreDomain : IdentityUtil.getPrimaryDomainName();
-            if (!IdentityUtil.isUserStoreCaseSensitive(caseDomain, tenantId)) {
+            boolean caseSensitiveStore = IdentityUtil.isUserStoreCaseSensitive(caseDomain, tenantId);
+            // AUTHDIAG (temporary) - the passkey username normalisation branch.
+            log.info("AUTHDIAG fido-normalize-case caseDomain=" + caseDomain
+                    + " caseSensitive=" + caseSensitiveStore);
+            if (!caseSensitiveStore) {
                 String storedUsername = resolveStoredPasskeyUsername(
                         FIDOUtil.getUsernameWithoutDomain(username), tenantDomain, userStoreDomain);
+                // Usernames are not logged; only whether one was found and whether it differed.
+                log.info("AUTHDIAG fido-normalize-stored found=" + StringUtils.isNotBlank(storedUsername)
+                        + " differsFromRequest=" + (StringUtils.isNotBlank(storedUsername)
+                                && !storedUsername.equals(FIDOUtil.getUsernameWithoutDomain(username))));
                 if (StringUtils.isNotBlank(storedUsername)) {
                     username = storedUsername;
                 }
@@ -1515,8 +1602,14 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             throws AuthenticationFailedException {
 
         List<AuthHistory> authHistory = context.getAuthenticationStepHistory();
-        if (authHistory != null && !authHistory.isEmpty() &&
-                IDF_AUTHENTICATOR.equals(authHistory.get(0).getAuthenticatorName())) {
+        String firstAuthenticator = (authHistory != null && !authHistory.isEmpty())
+                ? authHistory.get(0).getAuthenticatorName() : null;
+        boolean willNormalize = IDF_AUTHENTICATOR.equals(firstAuthenticator);
+        // AUTHDIAG (temporary) - normalisation only runs when identifier first was the first step.
+        log.info("AUTHDIAG fido-idf-check firstAuthenticator=" + firstAuthenticator
+                + " expected=" + IDF_AUTHENTICATOR + " willNormalize=" + willNormalize
+                + " historySize=" + (authHistory == null ? -1 : authHistory.size()));
+        if (willNormalize) {
             return normalizeAuthenticatedUser(context, user);
         } else {
             return user;

--- a/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.fido/src/main/java/org/wso2/carbon/identity/application/authenticator/fido/FIDOAuthenticator.java
@@ -1484,6 +1484,10 @@ public class FIDOAuthenticator extends AbstractApplicationAuthenticator
             authenticatedUser.setUserStoreDomain(userStoreDomain);
         }
 
+        // AUTHDIAG (temporary) - this method sets the domain but never the user id.
+        log.info("AUTHDIAG fido-normalize outDomain=" + authenticatedUser.getUserStoreDomain()
+                + " userIdSet=" + authenticatedUser.isUserIdExists());
+
         return authenticatedUser;
     }
 


### PR DESCRIPTION
> **This is temporary diagnostic logging. It will be reverted once the flow is identified, and must not reach production.**

## Purpose

Identify which code path first resolves `AuthenticatedUser.userId` during an identifier-first +
passkey login, and what user store domain is in effect at that moment.

Tracking issue: wso2-enterprise/asgardeo-product#36685
Related: wso2-iam-internal#7857 (groups missing from the token)

## Why it is needed

For affected logins the token carries the wrong user record — `sub` and all claims resolve to one
record while the passkey resolves against another. We have confirmed from dev diagnostic logs that
the `userId` is **null** at the end of the identifier-first step, so the ID is bound lazily somewhere
later. Which path does it, and with which domain, is the open question.

Correlation logs cannot answer this on their own: `AuthenticatedUser.getLoggableUserId()` and
`getLoggableMaskedUserId()` resolve the ID against the user store but never cache it, so a
`UM_USER_ID` query in the SQL log does not imply the ID was bound.

## Notes

- Every line is prefixed `AUTHDIAG` and marked `// AUTHDIAG (temporary)`, so the revert is a
  single grep.
- No usernames are logged in any form. User IDs are logged as-is, consistent with existing platform
  behaviour — `getLoggableMaskedUserId()` returns the user ID unmasked and masks only the username
  fallback, and `IdentifierHandler` / `FIDOAuthenticator` already log `USER_ID` raw. Caller traces
  contain class names and line numbers only.

## What is logged here

Every decision point in the FIDO user resolution, so the path taken is visible rather than inferred.

| marker | records |
|---|---|
| `fido-getuser` | which source the user came from: subject attribute step, last authenticated user, or none |
| `fido-idf-check` | the first authenticator in the step history, and whether identifier-first normalisation will run |
| `fido-normalize-in` | inputs to the domain decision: incoming domain, primary store domain and class, domain qualified, exists in primary, primary blocked, blocked list |
| `fido-normalize-walk` | whether the secondary store walk will run |
| `fido-normalize-try` | each secondary store considered, whether the user exists there, whether it is blocked |
| `fido-normalize-out` | resolved flag, chosen domain, whether the user was marked as existing only in blocked domains |
| `fido-normalize-case` | case sensitivity of the chosen store |
| `fido-normalize-stored` | whether a stored passkey username was found, and whether it differed from the request |
| `fido-normalize` | domain and user id state on exit |
| `fido-block-gate` | the gate that diverts to the passkey status page, with both conditions |
| `fido-mal-gate` / `fido-mal-result` / `fido-mal-set` | the multi attribute login branch — **one of the few places the connector itself writes the user id** |
| `fido-challenge` | usernameless versus username challenge, and the identity the passkey lookup used |
| `fido-assertion` | which assertion path handled the response |
| `fido-usernameless-resolved` | the user the credential itself resolved to, when that path is taken |
| `fido-subject` | the subject handed back to the framework — the identity that becomes `sub` and drives claim resolution |

## Note

`initiateFido2AuthenticationRequest` calls `user.setUserId(...)` from the multi attribute login
branch. That is a place the connector can rebind the identity after the adaptive script has set the
user store domain, and it was not previously visible in any log.
